### PR TITLE
Add image parsing from RSS

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,48 @@
+<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->
+
+<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->
+
+
+## Overview
+
+<!-- Summarize your changes here. -->
+
+
+
+## Changes Made
+
+<!-- Include details of what your changes actually are and how it is intended to work. -->
+
+
+
+## Test Coverage
+
+<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->
+
+
+
+## Next Steps (delete if not applicable)
+
+<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->
+
+
+
+## Related PRs or Issues (delete if not applicable)
+
+<!-- List related PRs against other branches/repositories. -->
+
+
+
+## Screenshots (delete if not applicable)
+
+<!-- This could include of screenshots of the new feature / proof that the changes work. -->
+
+<details>
+
+  <summary>Screen Shot Name</summary>
+
+
+  <!-- Insert file link here. Newlines above and below your link are necessary for this to work. -->
+  
+
+</details>

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # volume-backend
+
+
+### Tools
+
+We also have a collection of tools in the `utils` folder.
+
+These include `createDummyData.ts` which populates the MongoDB table with some dummy data to run queries on and `rss-feed.ts` which combines the feeds from the publications listed in `publications.json`. Both scripts can be run with `ts-node <file>.ts`. 

--- a/package-lock.json
+++ b/package-lock.json
@@ -966,6 +966,15 @@
         "@types/node": "*"
       }
     },
+    "@types/cheerio": {
+      "version": "0.22.22",
+      "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.22.tgz",
+      "integrity": "sha512-05DYX4zU96IBfZFY+t3Mh88nlwSMtmmzSYaQkKN48T495VV1dkHSah6qYyDTN5ngaS0i0VonH37m+RuzSM0YiA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/connect": {
       "version": "3.4.33",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.33.tgz",
@@ -2098,6 +2107,11 @@
         }
       }
     },
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+    },
     "boxen": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-4.2.0.tgz",
@@ -2377,6 +2391,34 @@
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true
+    },
+    "cheerio": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
+      "integrity": "sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==",
+      "requires": {
+        "css-select": "~1.2.0",
+        "dom-serializer": "~0.1.1",
+        "entities": "~1.1.1",
+        "htmlparser2": "^3.9.1",
+        "lodash": "^4.15.0",
+        "parse5": "^3.0.1"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+          "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+        },
+        "parse5": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
+          "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+          "requires": {
+            "@types/node": "*"
+          }
+        }
+      }
     },
     "chokidar": {
       "version": "3.4.3",
@@ -2712,6 +2754,22 @@
       "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
       "dev": true
     },
+    "css-select": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+      "requires": {
+        "boolbase": "~1.0.0",
+        "css-what": "2.1",
+        "domutils": "1.5.1",
+        "nth-check": "~1.0.1"
+      }
+    },
+    "css-what": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
+      "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
+    },
     "cssfilter": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
@@ -2934,6 +2992,27 @@
         "esutils": "^2.0.2"
       }
     },
+    "dom-serializer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+      "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+      "requires": {
+        "domelementtype": "^1.3.0",
+        "entities": "^1.1.1"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+          "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
+    },
     "domexception": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
@@ -2949,6 +3028,23 @@
           "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
           "dev": true
         }
+      }
+    },
+    "domhandler": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+      "requires": {
+        "domelementtype": "1"
+      }
+    },
+    "domutils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+      "requires": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
       }
     },
     "dot-prop": {
@@ -4284,6 +4380,36 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "htmlparser2": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+      "requires": {
+        "domelementtype": "^1.3.1",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+          "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "http-cache-semantics": {
       "version": "4.1.0",
@@ -6212,6 +6338,14 @@
           "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "dev": true
         }
+      }
+    },
+    "nth-check": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+      "requires": {
+        "boolbase": "~1.0.0"
       }
     },
     "nwsapi": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@typegoose/typegoose": "^7.4.1",
     "apollo-graphql": "^0.6.0",
     "apollo-server-express": "^2.18.2",
+    "cheerio": "^1.0.0-rc.3",
     "class-validator": "^0.12.2",
     "express": "^4.17.1",
     "graphql": "^15.3.0",
@@ -34,17 +35,18 @@
     "type-graphql": "^1.1.0"
   },
   "devDependencies": {
+    "@types/cheerio": "^0.22.22",
     "@types/express": "^4.17.8",
     "@types/jest": "^26.0.15",
     "@types/mongoose": "^5.7.36",
     "@types/node": "^14.11.4",
+    "dotenv": "^8.2.0",
     "eslint": "^7.12.1",
     "eslint-config-airbnb-typescript-prettier": "^3.1.0",
     "husky": "^4.3.0",
+    "jest": "^26.6.1",
     "nodemon": "^2.0.4",
     "prettier": "^2.1.2",
-    "dotenv": "^8.2.0",
-    "jest": "^26.6.1",
     "ts-jest": "^26.4.2",
     "ts-node": "^9.0.0",
     "typescript": "^4.0.3"

--- a/src/db/rss-parser.ts
+++ b/src/db/rss-parser.ts
@@ -1,4 +1,5 @@
 import Parser from 'rss-parser';
+import cheerio from 'cheerio';
 import { Article } from '../entities/Article';
 import publicationsJSON from '../../publications.json';
 
@@ -16,6 +17,12 @@ const getRecentArticles = async (): Promise<Article[]> => {
     return parser.parseURL(articles);
   });
 
+  const parseImage = function (content) {
+    const $ = cheerio.load(content);
+    const img = $('img').attr('src');
+    return img || '';
+  };
+
   const articlePromises = Promise.all(parsedPublications).then((publications) =>
     publications
       .map((publication) =>
@@ -23,7 +30,9 @@ const getRecentArticles = async (): Promise<Article[]> => {
           Object.assign(new Article(), {
             articleURL: article.link,
             date: new Date(article.pubDate),
-            imageURL: '',
+            imageURL: parseImage(
+              article['content:encoded'] ? article['content:encoded'] : article.content,
+            ),
             likes: 0,
             publication: nameToSlugMap[publication.title]
               ? nameToSlugMap[publication.title]

--- a/utils/rss-feed.ts
+++ b/utils/rss-feed.ts
@@ -1,25 +1,19 @@
 import Parser from 'rss-parser';
 import dotenv from 'dotenv';
 import express from 'express';
+import publicationsJSON from '../publications.json';
 
-const PORT = process.env.APP_PORT || 5000;
+const PORT = 5000;
 
 // load the environment variables from the .env file
 dotenv.config({
     path: '.env',
 });
 
-const FEED_LIST = ['https://cornellsun.com/feed/',
-                   'http://cunooz.com/?feed=rss2',
-                   'http://theadvocatecornell.com/feed/',
-                   'https://medium.com/feed/guac-magazine',
-                   'https://www.cornellclaritas.com/blog?format=rss',
-                   'https://www.culsr.org/?format=rss',
-                   'https://www.cremedecornell.net/blogposts?format=rss',
-                   'https://www.slopemedia.org/all?format=rss',
-                   'https://www.thecornellreview.org/feed/',
-                   'https://www.bigredsportsnetwork.org/feed/'
-];
+const publicationsDB = publicationsJSON.publications;
+const FEED_LIST = publicationsDB.map((publication) => {
+    return publication.feed;
+  });
 
 const app = express();
 

--- a/utils/rss-feed.ts
+++ b/utils/rss-feed.ts
@@ -1,0 +1,38 @@
+import Parser from 'rss-parser';
+import dotenv from 'dotenv';
+import express from 'express';
+
+const PORT = process.env.APP_PORT || 5000;
+
+// load the environment variables from the .env file
+dotenv.config({
+    path: '.env',
+});
+
+const FEED_LIST = ['https://cornellsun.com/feed/',
+                   'http://cunooz.com/?feed=rss2',
+                   'http://theadvocatecornell.com/feed/',
+                   'https://medium.com/feed/guac-magazine',
+                   'https://www.cornellclaritas.com/blog?format=rss',
+                   'https://www.culsr.org/?format=rss',
+                   'https://www.cremedecornell.net/blogposts?format=rss',
+                   'https://www.slopemedia.org/all?format=rss',
+                   'https://www.thecornellreview.org/feed/',
+                   'https://www.bigredsportsnetwork.org/feed/'
+];
+
+const app = express();
+
+app.get('/', (req, res) => {
+    const parser = new Parser();
+
+    const feedRequests = FEED_LIST.map((feed) => {
+        return parser.parseURL(feed);
+    });
+
+    Promise.all(feedRequests).then((response) => {
+        res.setHeader('Access-Control-Allow-Origin', '*');
+        res.header('Access-Control-Allow-Methods', 'GET');
+        res.json(response);
+    });
+}).listen(PORT, () => console.log(`Listening on ${PORT}`));


### PR DESCRIPTION
Adds image parsing through [cheerio](https://cheerio.js.org/). 

Article data in HTML is contained in RSS through either the `content` or `content:encoded` tags with `content:encoded` being guaranteed (at least in the case of these RSS feeds) to have HTML content. `content:encoded` may not be specified in an RSS feed, but `content` is guaranteed (by specification) and this may contain HTML content. So we check `content:encoded` first to see if it exists and otherwise fall back to `content` for an HTML string. This is then searched with cheerio to find the first image tag (when searching through an RSS feed content, image data is always supposed to be relevant to the article so we avoid mistakes with selecting extraneous content). 

Not all articles will have images, so we fall back to empty string in the cases where no image is associated with the article. This could be because either the publication isn't really about images in articles (The Undergraduate Law & Society Review never has any) or there is no image associated with the article by design (op-ed pieces). 

A possible way to improve this parsing method is to make scrappers that are publication specific. Cornell Daily Sun uses an alternative method for their main images in articles, and all this (usually) gets are images within the article and not the main header image. However, this strategy works for smaller publications as their header images are contained within the RSS feed.

Also created a utility to merge all RSS feeds into one feed in the `utils` folder and a PR template. Also I messed up last time and accidentally merged the last PR. I disabled this in the repo settings and now we should only be able to squash and merge.

## Testing

This method provides the highest percentage of articles with images (~68% of articles from today). I'm not 100% sure all the images are relevant to the article, but all of the ones I've checked are. I really hope we don't put up any bad images.