### PR TITLE
Add Github Actions deployment workflow to production server

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,45 @@
+name: Docker Build & Push and Deploy to volume-backend
+
+on:
+  push:
+    branches: [release]
+
+jobs:
+  path-context:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Get SHA
+        id: vars
+        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+      - name: Docker Build & Push
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile
+          push: true
+          tags: cornellappdev/volume:${{ steps.vars.outputs.sha_short }}
+      - name: Remote SSH and Deploy
+        uses: appleboy/ssh-action@master
+        env:
+          IMAGE_TAG: ${{ steps.vars.outputs.sha_short }}
+        with:
+          host: ${{ secrets.PROD_SERVER_HOST }}
+          username: ${{ secrets.SERVER_USERNAME }}
+          key: ${{ secrets.PROD_SERVER_KEY }}
+          script: |
+            export IMAGE_TAG=${{ steps.vars.outputs.sha_short }}
+            cd docker-compose
+            docker stack rm the-stack
+            sleep 20s
+            sudo systemctl stop nginx
+            sudo systemctl restart nginx
+            docker stack deploy -c docker-compose.yml the-stack


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview
Builds docker image off of branch `release` (note: @tedim52 @orkosinha you will have to manually merge into this branch! as this is not `main`), tags it, pushes it, and deploys onto production server `volume-backend`


## Changes Made
Add new workflow yaml for production deployment

## Next Steps
@tedim52 make sure that you try this out (deploy onto a branch named `release` that you can just create manually) at a time that you don't think users will be using the app, and seeing if the backend works (check the progress in Github Actions and also ssh into the server to see what's going on with `docker service ls` and `docker ps`)

## Related PRs or Issues
Closes #17 


