### PR TITLE
Onboarding Cornell Data Journal and Cornell Business Review

### DIFF
--- a/publications.json
+++ b/publications.json
@@ -72,7 +72,7 @@
       {
          "bio":"We are a group of passionate food enthusiasts who come together to publish a diversity of recipes, articles and stories.",
          "bioShort":"Recipes, stories, and articles from group of passionate food enthusiasts",
-         "rssName":"Blog - CRÈME de cornell",
+         "rssName":"Blog - Crème De Cornell",
          "rssURL":"https://www.cremedecornell.net/blogposts?format=rss",
          "name":"Crème de Cornell",
          "slug":"creme",
@@ -244,18 +244,6 @@
             }
          ],
          "websiteURL":"https://cornelldatajourn.al/"
-      },
-      {
-
-         "bio":"The Scheinman Conflict Resolution Club (SCRC) connects undergraduates, graduate students, alumni, faculty, and current practioners to learn more about the world of alternative dispute resolution.  Partnering with the Scheinman Institute, SCRC collaborates with world-renowned neutrals to teach students about mediation, arbitration, negotiations, and other forms of conflict resolution.",
-         "bioShort":"Exploring alternative dispute resolution through student-led research.",
-         "rssName":"Scheinman Institute Blog",
-         "rssURL":"https://www.ilr.cornell.edu/blog/14/feed",
-         "name":"Resolved",
-         "slug":"reso",
-         "socialURLs":[
-         ],
-         "websiteURL":"https://www.ilr.cornell.edu/scheinman-institute/blog/student-activities"
-         }
+      }
    ]
 }

--- a/publications.json
+++ b/publications.json
@@ -198,7 +198,7 @@
       {
          "bio":"Publication for the Cornell Hotel Administration Community.",
          "bioShort":"Publication for the Cornell Hotel Administration Community.",
-         "rssName":"The 180",
+         "rssName":"The 180 Blog - The 180",
          "rssURL":"https://www.the180print.org/the-180-blog?format=rss",
          "name":"The 180 at Cornell",
          "slug":"180",
@@ -219,20 +219,9 @@
          "websiteURL":"https://www.the180print.org/"
       },
       {
-         "bio":"Resolved -----",
-         "bioShort":"Resolved ----",
-         "rssName":"Resolved",
-         "rssURL":"https://www.ilr.cornell.edu/blog/14/feed",
-         "name":"Resolved",
-         "slug":"reso",
-         "socialURLs":[
-         ],
-         "websiteURL":"https://www.ilr.cornell.edu/scheinman-institute/blog/student-activities"
-      },
-      {
          "bio":"We are a community of Cornell students who love creating.",
          "bioShort":"We are a community of Cornell students who love creating.",
-         "rssName":"Cornell Creatives",
+         "rssName":"Cornell Creatives Newsletter",
          "rssURL":"https://cornell.substack.com/feed",
          "name":"Cornell Creatives Blog",
          "slug":"creat",
@@ -255,7 +244,7 @@
       {
          "bio":"A silly, not altogether normal dream about two state senators from Missouri and a jar of spicy dijon mustard.",
          "bioShort":"A silly, not altogether normal dream about two state senators from Missouri and a jar of spicy dijon mustard.",
-         "rssName":"Cornell Lunatic",
+         "rssName":"The Cornell Lunatic",
          "rssURL":"http://cornelllunatic.com/?feed=rss2",
          "name":"Cornell Lunatic",
          "slug":"lunatic",
@@ -276,9 +265,9 @@
          "websiteURL":"http://cornelllunatic.com/"
       },
       {
-         "bio":"A silly, not altogether normal dream about two state senators from Missouri and a jar of spicy dijon mustard.",
-         "bioShort":"A silly, not altogether normal dream about two state senators from Missouri and a jar of spicy dijon mustard.",
-         "rssName":"Cornell Business Review",
+         "bio":"<placeholder>",
+         "bioShort":"<placeholder>",
+         "rssName":"CBRnow - Cornell Business Review",
          "rssURL":"http://www.thecornellbusinessreview.com/cbrnow?format=rss",
          "name":"Cornell Business Review",
          "slug":"cbr",

--- a/publications.json
+++ b/publications.json
@@ -221,6 +221,21 @@
             }
          ],
          "websiteURL":"https://cornelldatajourn.al/"
+      },
+      {
+         "bio":"A student-run magazine that discusses business issues, trends, and debates among college students and alumni, CBR provides insight into recent events and passes along advice from student entrepreneurs and industry leaders and pioneers.",
+         "bioShort":"Cornell Business Review is the premier business publication at Cornell University.",
+         "rssName":"CBRnow - Cornell Business Review",
+         "rssURL":"http://www.thecornellbusinessreview.com/cbrnow?format=rss",
+         "name":"Cornell Business Review",
+         "slug":"cbr",
+         "socialURLs":[
+            {
+               "social":"linkedin",
+               "URL":"https://www.linkedin.com/company/cornell-business-review/"
+            }
+         ],
+         "websiteURL":"http://www.thecornellbusinessreview.com/cbr-now"
       }
    ]
 }

--- a/publications.json
+++ b/publications.json
@@ -196,29 +196,6 @@
          "websiteURL":"https://www.culsr.org/"
       },
       {
-         "bio":"The 180 is a publication by Hotelies for Hotelies. We aim to not only highlight the culture of Cornell University’s Hotel School through a 180 degree perspective, but to also capsule the community’s memories physically through an annual print.",
-         "bioShort":"The 180 is a publication by Hotelies for Hotelies.",
-         "rssName":"The 180 Blog - The 180",
-         "rssURL":"https://www.the180print.org/the-180-blog?format=rss",
-         "name":"The 180 at Cornell",
-         "slug":"180",
-         "socialURLs":[
-            {
-               "social":"insta",
-               "URL":"https://www.instagram.com/the_180_cornell/?hl=en"
-            },
-            {
-               "social":"facebook",
-               "URL":"https://www.facebook.com/Cornell.the180/"
-            },
-            {
-               "social":"linkedin",
-               "URL":"https://www.linkedin.com/company/cornell-the180/"
-            }
-         ],
-         "websiteURL":"https://www.the180print.org/"
-      },
-      {
          "bio":"Cornell Data Journal is an online investigative journalism publication featuring data visualization, data communication, and interdisciplinary research pieces.",
          "bioShort":"Offering data-driven perspectives on current events, academics, politics, and beyond.",
          "rssName":"Cornell Data Journal",

--- a/publications.json
+++ b/publications.json
@@ -196,8 +196,8 @@
          "websiteURL":"https://www.culsr.org/"
       },
       {
-         "bio":"Publication for the Cornell Hotel Administration Community.",
-         "bioShort":"Publication for the Cornell Hotel Administration Community.",
+         "bio":"The 180 is a publication by Hotelies for Hotelies. We aim to not only highlight the culture of Cornell University’s Hotel School through a 180 degree perspective, but to also capsule the community’s memories physically through an annual print.",
+         "bioShort":"The 180 is a publication by Hotelies for Hotelies.",
          "rssName":"The 180 Blog - The 180",
          "rssURL":"https://www.the180print.org/the-180-blog?format=rss",
          "name":"The 180 at Cornell",
@@ -219,69 +219,8 @@
          "websiteURL":"https://www.the180print.org/"
       },
       {
-         "bio":"We are a community of Cornell students who love creating.",
-         "bioShort":"We are a community of Cornell students who love creating.",
-         "rssName":"Cornell Creatives Newsletter",
-         "rssURL":"https://cornell.substack.com/feed",
-         "name":"Cornell Creatives Blog",
-         "slug":"creat",
-         "socialURLs":[
-            {
-               "social":"insta",
-               "URL":"https://www.instagram.com/cornellcreatives/"
-            },
-            {
-               "social":"facebook",
-               "URL":"https://www.facebook.com/cornellcreatives/"
-            },
-            {
-               "social":"linkedin",
-               "URL":"https://www.linkedin.com/company/30581251/"
-            }
-         ],
-         "websiteURL":"https://cornellcreatives.com/"
-      },
-      {
-         "bio":"A silly, not altogether normal dream about two state senators from Missouri and a jar of spicy dijon mustard.",
-         "bioShort":"A silly, not altogether normal dream about two state senators from Missouri and a jar of spicy dijon mustard.",
-         "rssName":"The Cornell Lunatic",
-         "rssURL":"http://cornelllunatic.com/?feed=rss2",
-         "name":"Cornell Lunatic",
-         "slug":"lunatic",
-         "socialURLs":[
-            {
-               "social":"insta",
-               "URL":"http://instagram.com/thecornelllunatic"
-            },
-            {
-               "social":"twitter",
-               "URL":"https://twitter.com/cornelllunatic"
-            },
-            {
-               "social":"facebook",
-               "URL":"http://facebook.com/thecornelllunatic"
-            }
-         ],
-         "websiteURL":"http://cornelllunatic.com/"
-      },
-      {
-         "bio":"<placeholder>",
-         "bioShort":"<placeholder>",
-         "rssName":"CBRnow - Cornell Business Review",
-         "rssURL":"http://www.thecornellbusinessreview.com/cbrnow?format=rss",
-         "name":"Cornell Business Review",
-         "slug":"cbr",
-         "socialURLs":[
-            {
-               "social":"linkedin",
-               "URL":"https://www.linkedin.com/company/cornell-business-review/"
-            }
-         ],
-         "websiteURL":"http://www.thecornellbusinessreview.com/cbr-now"
-      },
-      {
          "bio":"Cornell Data Journal is an online investigative journalism publication featuring data visualization, data communication, and interdisciplinary research pieces.",
-         "bioShort":"offering data-driven perspectives on current events, academics, politics, and beyond.",
+         "bioShort":"Offering data-driven perspectives on current events, academics, politics, and beyond.",
          "rssName":"Cornell Data Journal",
          "rssURL":"https://cdj-git-add-rss-ashpil.vercel.app/rss.xml",
          "name":"Cornell Data Journal",
@@ -305,6 +244,18 @@
             }
          ],
          "websiteURL":"https://cornelldatajourn.al/"
-      }
+      },
+      {
+
+         "bio":"The Scheinman Conflict Resolution Club (SCRC) connects undergraduates, graduate students, alumni, faculty, and current practioners to learn more about the world of alternative dispute resolution.  Partnering with the Scheinman Institute, SCRC collaborates with world-renowned neutrals to teach students about mediation, arbitration, negotiations, and other forms of conflict resolution.",
+         "bioShort":"Exploring alternative dispute resolution through student-led research.",
+         "rssName":"Scheinman Institute Blog",
+         "rssURL":"https://www.ilr.cornell.edu/blog/14/feed",
+         "name":"Resolved",
+         "slug":"reso",
+         "socialURLs":[
+         ],
+         "websiteURL":"https://www.ilr.cornell.edu/scheinman-institute/blog/student-activities"
+         }
    ]
 }

--- a/publications.json
+++ b/publications.json
@@ -194,6 +194,128 @@
             }
          ],
          "websiteURL":"https://www.culsr.org/"
+      },
+      {
+         "bio":"Publication for the Cornell Hotel Administration Community.",
+         "bioShort":"Publication for the Cornell Hotel Administration Community.",
+         "rssName":"The 180",
+         "rssURL":"https://www.the180print.org/the-180-blog?format=rss",
+         "name":"The 180 at Cornell",
+         "slug":"180",
+         "socialURLs":[
+            {
+               "social":"insta",
+               "URL":"https://www.instagram.com/the_180_cornell/?hl=en"
+            },
+            {
+               "social":"facebook",
+               "URL":"https://www.facebook.com/Cornell.the180/"
+            },
+            {
+               "social":"linkedin",
+               "URL":"https://www.linkedin.com/company/cornell-the180/"
+            }
+         ],
+         "websiteURL":"https://www.the180print.org/"
+      },
+      {
+         "bio":"Resolved -----",
+         "bioShort":"Resolved ----",
+         "rssName":"Resolved",
+         "rssURL":"https://www.ilr.cornell.edu/blog/14/feed",
+         "name":"Resolved",
+         "slug":"reso",
+         "socialURLs":[
+         ],
+         "websiteURL":"https://www.ilr.cornell.edu/scheinman-institute/blog/student-activities"
+      },
+      {
+         "bio":"We are a community of Cornell students who love creating.",
+         "bioShort":"We are a community of Cornell students who love creating.",
+         "rssName":"Cornell Creatives",
+         "rssURL":"https://cornell.substack.com/feed",
+         "name":"Cornell Creatives Blog",
+         "slug":"creat",
+         "socialURLs":[
+            {
+               "social":"insta",
+               "URL":"https://www.instagram.com/cornellcreatives/"
+            },
+            {
+               "social":"facebook",
+               "URL":"https://www.facebook.com/cornellcreatives/"
+            },
+            {
+               "social":"linkedin",
+               "URL":"https://www.linkedin.com/company/30581251/"
+            }
+         ],
+         "websiteURL":"https://cornellcreatives.com/"
+      },
+      {
+         "bio":"A silly, not altogether normal dream about two state senators from Missouri and a jar of spicy dijon mustard.",
+         "bioShort":"A silly, not altogether normal dream about two state senators from Missouri and a jar of spicy dijon mustard.",
+         "rssName":"Cornell Lunatic",
+         "rssURL":"http://cornelllunatic.com/?feed=rss2",
+         "name":"Cornell Lunatic",
+         "slug":"lunatic",
+         "socialURLs":[
+            {
+               "social":"insta",
+               "URL":"http://instagram.com/thecornelllunatic"
+            },
+            {
+               "social":"twitter",
+               "URL":"https://twitter.com/cornelllunatic"
+            },
+            {
+               "social":"facebook",
+               "URL":"http://facebook.com/thecornelllunatic"
+            }
+         ],
+         "websiteURL":"http://cornelllunatic.com/"
+      },
+      {
+         "bio":"A silly, not altogether normal dream about two state senators from Missouri and a jar of spicy dijon mustard.",
+         "bioShort":"A silly, not altogether normal dream about two state senators from Missouri and a jar of spicy dijon mustard.",
+         "rssName":"Cornell Business Review",
+         "rssURL":"http://www.thecornellbusinessreview.com/cbrnow?format=rss",
+         "name":"Cornell Business Review",
+         "slug":"cbr",
+         "socialURLs":[
+            {
+               "social":"linkedin",
+               "URL":"https://www.linkedin.com/company/cornell-business-review/"
+            }
+         ],
+         "websiteURL":"http://www.thecornellbusinessreview.com/cbr-now"
+      },
+      {
+         "bio":"Cornell Data Journal is an online investigative journalism publication featuring data visualization, data communication, and interdisciplinary research pieces.",
+         "bioShort":"offering data-driven perspectives on current events, academics, politics, and beyond.",
+         "rssName":"Cornell Data Journal",
+         "rssURL":"https://cdj-git-add-rss-ashpil.vercel.app/rss.xml",
+         "name":"Cornell Data Journal",
+         "slug":"cdj",
+         "socialURLs":[
+            {
+               "social":"twitter",
+               "URL":"https://cornelldatajourn.al/socials/twitter.svg"
+            },
+            {
+               "social":"linkedin",
+               "URL":"https://www.linkedin.com/company/cornell-data-journal/"
+            },
+            {
+               "social":"facebook",
+               "URL":"https://www.facebook.com/cornelldatajournal/"
+            },
+            {
+               "social":"insta",
+               "URL":"https://www.instagram.com/cornelldatajournal/"
+            }
+         ],
+         "websiteURL":"https://cornelldatajourn.al/"
       }
    ]
 }

--- a/src/repos/ArticleRepo.ts
+++ b/src/repos/ArticleRepo.ts
@@ -89,27 +89,6 @@ const refreshFeed = async (): Promise<Article[]> => {
   return articles;
 };
 
-// /**
-//  * Creates a new article object and inserts it into database.
-//  */
-// const createArticle = async (
-//   title: string,
-//   articleURL: string,
-//   pubDate: string,
-//   pub: string,
-//   content: string,
-// ): Promise<Article> => {
-//   const articleObject = Object.assign(new Article(), {
-//     articleURL,
-//     date: new Date(pubDate),
-//     imageURL: content,
-//     publicationSlug: pub,
-//     title,
-//   });
-//   const articleDoc = await ArticleModel.insertMany(articleObject, { ordered: false });
-//   return articleDoc;
-// };
-
 /**
  * Increments number of shoutouts on an article and publication by one.
  * @function

--- a/src/resolvers/ArticleResolver.ts
+++ b/src/resolvers/ArticleResolver.ts
@@ -70,17 +70,6 @@ class ArticleResolver {
     return ArticleRepo.refreshFeed();
   }
 
-  // @Mutation((_returns) => Article)
-  // async createArticle(
-  //   @Arg('title') title: string,
-  //   @Arg('articleURL') articleURL: string,
-  //   @Arg('pubDate') pubDate: string,
-  //   @Arg('pub') pub: string,
-  //   @Arg('content') content: string,
-  // ) {
-  //   return ArticleRepo.createArticle(title, articleURL, pubDate, pub, content);
-  // }
-
   @Mutation((_returns) => Article)
   async incrementShoutouts(@Arg('id') id: string) {
     return ArticleRepo.incrementShoutouts(id);


### PR DESCRIPTION

## Overview

This PR onboards the Cornell Data Journal and the Cornell Business Review onto Volume. In a coming PR, I plan to onboard The 180, Resolved, Cornell Lunatic, Cornell Creatives. I am using this PR as a test. (Also waiting on assets from some publications)


## Changes Made
-publications.json



## Test Coverage

Manual testing to check if articles from CDJ rss feed were being parsed, inserted into db, and returned.


## Next Steps 
- Onboard remaining publications
