### PR TITLE
Add yes input to docker system prune -a in auto deployment

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -45,4 +45,4 @@ jobs:
             sudo systemctl stop nginx
             sudo systemctl restart nginx
             docker stack deploy -c docker-compose.yml the-stack
-            docker system prune -a
+            yes | docker system prune -a

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -45,4 +45,4 @@ jobs:
             sudo systemctl stop nginx
             sudo systemctl restart nginx
             docker stack deploy -c docker-compose.yml the-stack
-            docker system prune -a
+            yes | docker system prune -a


### PR DESCRIPTION
Turns out we haven't been pruning automatically because Docker asks for confirmation on whether or not you'd like to nuke all the images not being used -- so I'm just piping in the `yes`! 

ez fix ;) 