### PR TITLE
Fix getArticlesByPublicationID to support new schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/app.ts",
   "scripts": {
     "start": "migrate-mongo up && ts-node src/app.ts",
-    "dev": "migrate-mongo up && nodemon src/app.ts",
+    "dev": "nodemon src/app.ts",
     "newman": "node_modules/.bin/newman run tests/Volume\\ Testing.postman_collection.json",
     "test": "npm start & wait-on http://localhost:$APP_PORT && npm run newman && kill $(lsof -t -i:$APP_PORT)",
     "lint": "eslint src/**/*.ts --fix",

--- a/src/repos/ArticleRepo.ts
+++ b/src/repos/ArticleRepo.ts
@@ -2,6 +2,7 @@ import Filter from 'bad-words';
 import { ObjectId } from 'mongodb';
 import { Article, ArticleModel } from '../entities/Article';
 import { DEFAULT_LIMIT, MAX_NUM_DAYS_OF_TRENDING_ARTICLES } from '../common/constants';
+import { PublicationModel } from '../entities/Publication';
 
 const getArticleByID = async (id: string): Promise<Article> => {
   return ArticleModel.findById(new ObjectId(id));
@@ -20,7 +21,8 @@ const getAllArticles = async (limit = DEFAULT_LIMIT): Promise<Article[]> => {
 };
 
 const getArticlesByPublicationID = async (publicationID: string): Promise<Article[]> => {
-  return ArticleModel.find({ 'publication.id': publicationID });
+  const publication = await (await PublicationModel.findById(publicationID)).execPopulate();
+  return ArticleModel.find({ 'publication.slug': publication.slug });
 };
 
 const getArticlesByPublicationIDs = async (publicationIDs: string[]): Promise<Article[]> => {


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->

Quick fix to allow getArticlesByPublicationID to function as intended. Should be deprecated in migrating publication IDs to slugs.


## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->

Fixes the query in GraphQL by redefining the function. Now it retrieves the publication from the database and queries the articles collection by the slug of the publication.

