### PR TITLE
Revert docker node version to 16.14.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:16.14.0
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 COPY . .


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

Revert docker node version to 16.14.0 since the latest version of node was crashing the dev server. The issue within the link was causing the error.


## Changes Made

Reverted node from version 17.5.0 to 16.14.0


## Related PRs or Issues

https://github.com/Automattic/mongoose/issues/11377

