### PR TITLE
Kidus/filter articles

### DIFF
--- a/migrations/add-filter.js
+++ b/migrations/add-filter.js
@@ -1,8 +1,11 @@
 module.exports = {
   async up(db) {
-    let Filter = require("../node_modules/bad-words");
+     /**
+     * Adds the `isFiltered` field to all articles.
+     */
+    let Filter = require('../node_modules/bad-words');
     const filter = new Filter({emptyList: true});
-    filter.addWords("covid-19","coronavirus", "pandemic","masks","mask")
+    filter.addWords('covid-19','coronavirus', 'pandemic','masks','mask')
     const articles = await db.collection('articles').find({}).toArray();
     articles.map( async (article) => {
         await db.collection('articles').updateOne({_id: article._id}, {$set: {isFiltered: filter.isProfane(article.title)}});
@@ -11,9 +14,12 @@ module.exports = {
   },
 
   async down(db) {
+    /**
+     * Reverts the changes to the mongo database.
+     */
     const articles = await db.collection('articles').find({}).toArray();
     articles.map( async (article) => {
-      await db.collection('articles').updateOne({_id: article._id}, {$unset: {isFiltered: ""}});
+      await db.collection('articles').updateOne({_id: article._id}, {$unset: {isFiltered: ''}});
       return article;
     });
     },

--- a/migrations/add-filter.js
+++ b/migrations/add-filter.js
@@ -1,0 +1,20 @@
+module.exports = {
+  async up(db) {
+    let Filter = require("../node_modules/bad-words");
+    const filter = new Filter({emptyList: true});
+    filter.addWords("covid-19","coronavirus", "pandemic","masks","mask")
+    const articles = await db.collection('articles').find({}).toArray();
+    articles.map( async (article) => {
+        await db.collection('articles').updateOne({_id: article._id}, {$set: {filtered: filter.isProfane(article.title)}});
+        return article;
+    });
+  },
+
+  async down(db) {
+    const articles = await db.collection('articles').find({}).toArray();
+    articles.map( async (article) => {
+      await db.collection('articles').updateOne({_id: article._id}, {$unset: {filtered: ""}});
+      return article;
+    });
+    },
+};

--- a/migrations/add-filter.js
+++ b/migrations/add-filter.js
@@ -5,7 +5,7 @@ module.exports = {
     filter.addWords("covid-19","coronavirus", "pandemic","masks","mask")
     const articles = await db.collection('articles').find({}).toArray();
     articles.map( async (article) => {
-        await db.collection('articles').updateOne({_id: article._id}, {$set: {filtered: filter.isProfane(article.title)}});
+        await db.collection('articles').updateOne({_id: article._id}, {$set: {isFiltered: filter.isProfane(article.title)}});
         return article;
     });
   },
@@ -13,7 +13,7 @@ module.exports = {
   async down(db) {
     const articles = await db.collection('articles').find({}).toArray();
     articles.map( async (article) => {
-      await db.collection('articles').updateOne({_id: article._id}, {$unset: {filtered: ""}});
+      await db.collection('articles').updateOne({_id: article._id}, {$unset: {isFiltered: ""}});
       return article;
     });
     },

--- a/migrations/embed-publications.js
+++ b/migrations/embed-publications.js
@@ -24,7 +24,7 @@ module.exports = {
   async down(db) {
     const articles = await db.collection('articles').find({}).toArray();
     articles.map( async (article) => {
-      await db.collection('articles').updateOne({_id: article._id}, {$unset: {publication: ""}});
+      await db.collection('articles').updateOne({_id: article._id}, {$unset: {publication: ''}});
       return article;
     });
     },

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -3,3 +3,4 @@ export const IMAGE_ADDRESS = 'https://raw.githubusercontent.com/cuappdev/assets/
 export const MAX_NUM_DAYS_OF_TRENDING_ARTICLES = 30;
 export const IOS = 'IOS';
 export const ANDROID = 'ANDROID';
+export const IS_FILTER_ACTIVE = true;

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,6 +1,6 @@
+export const ANDROID = 'ANDROID';
 export const DEFAULT_LIMIT = 25.0;
 export const IMAGE_ADDRESS = 'https://raw.githubusercontent.com/cuappdev/assets/master/volume';
-export const MAX_NUM_DAYS_OF_TRENDING_ARTICLES = 30;
 export const IOS = 'IOS';
-export const ANDROID = 'ANDROID';
 export const IS_FILTER_ACTIVE = true;
+export const MAX_NUM_DAYS_OF_TRENDING_ARTICLES = 30;

--- a/src/entities/Article.ts
+++ b/src/entities/Article.ts
@@ -42,6 +42,10 @@ export class Article {
   @Field()
   @Property({ default: false })
   isTrending: boolean;
+
+  @Field()
+  @Property()
+  filtered: boolean;
 }
 
 export const ArticleModel = getModelForClass(Article);

--- a/src/entities/Article.ts
+++ b/src/entities/Article.ts
@@ -45,7 +45,7 @@ export class Article {
 
   @Field()
   @Property()
-  filtered: boolean;
+  isFiltered: boolean;
 }
 
 export const ArticleModel = getModelForClass(Article);

--- a/src/repos/ArticleRepo.ts
+++ b/src/repos/ArticleRepo.ts
@@ -7,9 +7,9 @@ import { PublicationModel } from '../entities/Publication';
 const getArticleByID = async (id: string): Promise<Article> => {
   const article = ArticleModel.findById(new ObjectId(id));
   if((await article).filtered){
-    return article;
+    return null;
   }
-  return null;
+  return article;
 };
 
 const getArticlesByIDs = async (ids: string[]): Promise<Article[]> => {

--- a/src/repos/ArticleRepo.ts
+++ b/src/repos/ArticleRepo.ts
@@ -1,13 +1,17 @@
 import Filter from 'bad-words';
 import { ObjectId } from 'mongodb';
 import { Article, ArticleModel } from '../entities/Article';
-import { DEFAULT_LIMIT, MAX_NUM_DAYS_OF_TRENDING_ARTICLES } from '../common/constants';
+import { DEFAULT_LIMIT, MAX_NUM_DAYS_OF_TRENDING_ARTICLES, IS_FILTER_ACTIVE } from '../common/constants';
 import { PublicationModel } from '../entities/Publication';
+
+function isArticleFiltered(article: Article){
+  return IS_FILTER_ACTIVE && article.isFiltered;
+}
 
 const getArticleByID = async (id: string): Promise<Article> => {
   return ArticleModel.findById(new ObjectId(id)).then(
     (article) => {
-      if (!article.isFiltered){
+      if (!isArticleFiltered(article)){
         return article;
       }
     }
@@ -18,14 +22,14 @@ const getArticlesByIDs = async (ids: string[]): Promise<Article[]> => {
   return Promise.all(ids.map((id) => ArticleModel.findById(new ObjectId(id)))).then((articles) => {
     // Filter out all null values that were returned by ObjectIds not associated
     // with articles in database
-    return articles.filter((article) => article !== null && !article.isFiltered);
+    return articles.filter((article) => article !== null && !isArticleFiltered(article));
   });
 };
 
 const getAllArticles = async (limit = DEFAULT_LIMIT): Promise<Article[]> => {
   return ArticleModel.find({}).limit(limit).then((articles) =>
   { 
-    return articles.filter((article) => !article.isFiltered)
+    return articles.filter((article) => !isArticleFiltered(article))
   })
 };
 
@@ -33,7 +37,7 @@ const getArticlesByPublicationID = async (publicationID: string): Promise<Articl
   const publication = await (await PublicationModel.findById(publicationID)).execPopulate();
   return ArticleModel.find({ 'publication.slug': publication.slug }).then((articles)=>
   {
-    return articles.filter((article) => !article.isFiltered)
+    return articles.filter((article) => !isArticleFiltered(article))
   })
 };
 
@@ -56,7 +60,7 @@ const getArticlesAfterDate = async (since: string, limit = DEFAULT_LIMIT): Promi
       // Sort dates in order of most recent to least
       .sort({ date: 'desc' })
       .limit(limit).then((articles)=>{
-        return articles.filter((article) => !article.isFiltered)
+        return articles.filter((article) => !isArticleFiltered(article))
       })
   );
 };
@@ -69,7 +73,7 @@ const getArticlesAfterDate = async (since: string, limit = DEFAULT_LIMIT): Promi
  */
 const getTrendingArticles = async (limit = DEFAULT_LIMIT): Promise<Article[]> => {
   const articles = await ArticleModel.find({ isTrending: true }).exec();
-  return articles.filter((article) => !article.isFiltered).slice(0, limit);
+  return articles.filter((article) => !isArticleFiltered(article)).slice(0, limit);
 };
 
 /**


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

Add article filtering capability based on keywords defined in [volume microservice](https://github.com/cuappdev/volume-microservice).

## Changes Made
Merging this into release as an emergency patch for IOS to get an update out to the App Store.

Added a new field `isFiltered` and filtered articles on all article queries that had `isFiltered: true`. Migration script for existing articles is included. Also added a constant  `IS_FILTER_ACTIVE` to be able to toggle filtering on and off from the backend.


## Test Coverage

Tested through manual testing by checking whether articles with `isFiltered=true` would appear when queried.


## Related PRs or Issues

https://github.com/cuappdev/volume-microservice/pull/12

