### PR TITLE
Pagination Implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 *build/*
 nohup.out
 *src/certificates*
+Makefile
+start.sh

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,7 +1,18 @@
 export const ANDROID = 'ANDROID';
 export const DAYS_IN_WEEK = 7;
 export const DEFAULT_LIMIT = 25.0;
-export const FILTERED_WORDS = ['covid-19', 'covid', 'coronavirus', 'masks', 'mask','pandemic','test','testing','tests'];
+export const DEFAULT_OFFSET = 1;
+export const FILTERED_WORDS = [
+  'covid-19',
+  'covid',
+  'coronavirus',
+  'masks',
+  'mask',
+  'pandemic',
+  'test',
+  'testing',
+  'tests',
+];
 export const IMAGE_ADDRESS = 'https://raw.githubusercontent.com/cuappdev/assets/master/volume';
 export const IOS = 'IOS';
 export const IS_FILTER_ACTIVE = true;

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,7 +1,7 @@
 export const ANDROID = 'ANDROID';
 export const DAYS_IN_WEEK = 7;
 export const DEFAULT_LIMIT = 25.0;
-export const DEFAULT_OFFSET = 1;
+export const DEFAULT_OFFSET = 0;
 export const FILTERED_WORDS = [
   'covid-19',
   'covid',

--- a/src/repos/ArticleRepo.ts
+++ b/src/repos/ArticleRepo.ts
@@ -6,6 +6,7 @@ import {
   MAX_NUM_DAYS_OF_TRENDING_ARTICLES,
   IS_FILTER_ACTIVE,
   FILTERED_WORDS,
+  DEFAULT_OFFSET,
 } from '../common/constants';
 import { PublicationModel } from '../entities/Publication';
 
@@ -37,7 +38,10 @@ const getArticlesByIDs = async (ids: string[]): Promise<Article[]> => {
   });
 };
 
-const getAllArticles = async (offset = 0, limit = DEFAULT_LIMIT): Promise<Article[]> => {
+const getAllArticles = async (
+  offset = DEFAULT_OFFSET,
+  limit = DEFAULT_LIMIT,
+): Promise<Article[]> => {
   return ArticleModel.find({})
     .skip(offset)
     .limit(limit)
@@ -48,8 +52,8 @@ const getAllArticles = async (offset = 0, limit = DEFAULT_LIMIT): Promise<Articl
 
 const getArticlesByPublicationID = async (
   publicationID: string,
-  limit: number,
-  offset: number,
+  limit: number = DEFAULT_LIMIT,
+  offset: number = DEFAULT_OFFSET,
 ): Promise<Article[]> => {
   const publication = await (await PublicationModel.findById(publicationID)).execPopulate();
   return ArticleModel.find({ 'publication.slug': publication.slug })
@@ -62,8 +66,8 @@ const getArticlesByPublicationID = async (
 
 const getArticlesByPublicationIDs = async (
   publicationIDs: string[],
-  limit: number,
-  offset: number,
+  limit: number = DEFAULT_LIMIT,
+  offset: number = DEFAULT_OFFSET,
 ): Promise<Article[]> => {
   const uniquePubIDs = [...new Set(publicationIDs)];
   const articles = await Promise.all(
@@ -76,16 +80,16 @@ const getArticlesByPublicationIDs = async (
 
 const getArticlesByPublicationSlug = async (
   slug: string,
-  limit: number,
-  offset: number,
+  limit: number = DEFAULT_LIMIT,
+  offset: number = DEFAULT_OFFSET,
 ): Promise<Article[]> => {
   return ArticleModel.find({ 'publication.slug': slug }).skip(offset).limit(limit);
 };
 
 const getArticlesByPublicationSlugs = async (
   slugs: string[],
-  limit: number,
-  offset: number,
+  limit: number = DEFAULT_LIMIT,
+  offset: number = DEFAULT_OFFSET,
 ): Promise<Article[]> => {
   const uniqueSlugs = [...new Set(slugs)];
   const articles = await Promise.all(

--- a/src/repos/ArticleRepo.ts
+++ b/src/repos/ArticleRepo.ts
@@ -1,13 +1,19 @@
 import Filter from 'bad-words';
 import { ObjectId } from 'mongodb';
 import { Article, ArticleModel } from '../entities/Article';
-import { DEFAULT_LIMIT, MAX_NUM_DAYS_OF_TRENDING_ARTICLES, IS_FILTER_ACTIVE, FILTERED_WORDS} from '../common/constants';
+import {
+  DEFAULT_LIMIT,
+  MAX_NUM_DAYS_OF_TRENDING_ARTICLES,
+  IS_FILTER_ACTIVE,
+  FILTERED_WORDS,
+} from '../common/constants';
 import { PublicationModel } from '../entities/Publication';
 
-function isArticleFiltered(article: Article){
-  if(IS_FILTER_ACTIVE){
-    if (article.isFiltered){ // If the body has been checked already in microservice
-      return true; 
+function isArticleFiltered(article: Article) {
+  if (IS_FILTER_ACTIVE) {
+    if (article.isFiltered) {
+      // If the body has been checked already in microservice
+      return true;
     }
     const filter = new Filter({ list: FILTERED_WORDS });
     return filter.isProfane(article.title);
@@ -16,13 +22,11 @@ function isArticleFiltered(article: Article){
 }
 
 const getArticleByID = async (id: string): Promise<Article> => {
-  return ArticleModel.findById(new ObjectId(id)).then(
-    (article) => {
-      if (!isArticleFiltered(article)){
-        return article;
-      }
+  return ArticleModel.findById(new ObjectId(id)).then((article) => {
+    if (!isArticleFiltered(article)) {
+      return article;
     }
-  );
+  });
 };
 
 const getArticlesByIDs = async (ids: string[]): Promise<Article[]> => {
@@ -33,40 +37,60 @@ const getArticlesByIDs = async (ids: string[]): Promise<Article[]> => {
   });
 };
 
-const getAllArticles = async (limit = DEFAULT_LIMIT): Promise<Article[]> => {
-  return ArticleModel.find({}).limit(limit).then((articles) =>
-  { 
-    return articles.filter((article) => !isArticleFiltered(article))
-  })
+const getAllArticles = async (offset = 0, limit = DEFAULT_LIMIT): Promise<Article[]> => {
+  return ArticleModel.find({})
+    .skip(offset)
+    .limit(limit)
+    .then((articles) => {
+      return articles.filter((article) => !isArticleFiltered(article));
+    });
 };
 
-const getArticlesByPublicationID = async (publicationID: string): Promise<Article[]> => {
+const getArticlesByPublicationID = async (
+  publicationID: string,
+  limit: number,
+  offset: number,
+): Promise<Article[]> => {
   const publication = await (await PublicationModel.findById(publicationID)).execPopulate();
-  return ArticleModel.find({ 'publication.slug': publication.slug }).then((articles)=>
-  {
-    return articles.filter((article) => !isArticleFiltered(article))
-  })
+  return ArticleModel.find({ 'publication.slug': publication.slug })
+    .skip(offset)
+    .limit(limit)
+    .then((articles) => {
+      return articles.filter((article) => !isArticleFiltered(article));
+    });
 };
 
-const getArticlesByPublicationIDs = async (publicationIDs: string[]): Promise<Article[]> => {
+const getArticlesByPublicationIDs = async (
+  publicationIDs: string[],
+  limit: number,
+  offset: number,
+): Promise<Article[]> => {
   const uniquePubIDs = [...new Set(publicationIDs)];
   const articles = await Promise.all(
     uniquePubIDs.map(async (pubID) => {
-      return getArticlesByPublicationID(pubID);
+      return getArticlesByPublicationID(pubID, limit, offset);
     }),
   );
   return articles.flat();
 };
 
-const getArticlesByPublicationSlug = async (slug: string): Promise<Article[]> => {
-  return ArticleModel.find({ 'publication.slug': slug });
+const getArticlesByPublicationSlug = async (
+  slug: string,
+  limit: number,
+  offset: number,
+): Promise<Article[]> => {
+  return ArticleModel.find({ 'publication.slug': slug }).skip(offset).limit(limit);
 };
 
-const getArticlesByPublicationSlugs = async (slugs: string[]): Promise<Article[]> => {
+const getArticlesByPublicationSlugs = async (
+  slugs: string[],
+  limit: number,
+  offset: number,
+): Promise<Article[]> => {
   const uniqueSlugs = [...new Set(slugs)];
   const articles = await Promise.all(
     uniqueSlugs.map(async (slug) => {
-      return getArticlesByPublicationSlug(slug);
+      return getArticlesByPublicationSlug(slug, limit, offset);
     }),
   );
   return articles.flat();
@@ -80,8 +104,9 @@ const getArticlesAfterDate = async (since: string, limit = DEFAULT_LIMIT): Promi
     })
       // Sort dates in order of most recent to least
       .sort({ date: 'desc' })
-      .limit(limit).then((articles)=>{
-        return articles.filter((article) => !isArticleFiltered(article))
+      .limit(limit)
+      .then((articles) => {
+        return articles.filter((article) => !isArticleFiltered(article));
       })
   );
 };

--- a/src/resolvers/ArticleResolver.ts
+++ b/src/resolvers/ArticleResolver.ts
@@ -1,7 +1,7 @@
 import { Resolver, Mutation, Arg, Query, FieldResolver, Root } from 'type-graphql';
 import { Article } from '../entities/Article';
 import ArticleRepo from '../repos/ArticleRepo';
-import { DEFAULT_LIMIT } from '../common/constants';
+import { DEFAULT_LIMIT, DEFAULT_OFFSET } from '../common/constants';
 import UserRepo from '../repos/UserRepo';
 
 @Resolver((_of) => Article)
@@ -28,7 +28,7 @@ class ArticleResolver {
   })
   async getAllArticles(
     @Arg('limit', { defaultValue: DEFAULT_LIMIT }) limit: number,
-    @Arg('offset', { defaultValue: 0 }) offset: number,
+    @Arg('offset', { defaultValue: DEFAULT_OFFSET }) offset: number,
   ) {
     const articles = await ArticleRepo.getAllArticles(offset, limit);
     return articles;
@@ -42,7 +42,7 @@ class ArticleResolver {
   async getArticlesByPublicationID(
     @Arg('publicationID') publicationID: string,
     @Arg('limit', { defaultValue: DEFAULT_LIMIT }) limit: number,
-    @Arg('offset', { defaultValue: 0 }) offset: number,
+    @Arg('offset', { defaultValue: DEFAULT_OFFSET }) offset: number,
   ) {
     return ArticleRepo.getArticlesByPublicationID(publicationID, limit, offset);
   }
@@ -55,7 +55,7 @@ class ArticleResolver {
   async getArticlesByPublicationIDs(
     @Arg('publicationIDs', (type) => [String]) publicationIDs: string[],
     @Arg('limit', { defaultValue: DEFAULT_LIMIT }) limit: number,
-    @Arg('offset', { defaultValue: 0 }) offset: number,
+    @Arg('offset', { defaultValue: DEFAULT_OFFSET }) offset: number,
   ) {
     return ArticleRepo.getArticlesByPublicationIDs(publicationIDs, limit, offset);
   }
@@ -68,7 +68,7 @@ class ArticleResolver {
   async getArticlesByPublicationSlug(
     @Arg('slug') slug: string,
     @Arg('limit', { defaultValue: DEFAULT_LIMIT }) limit: number,
-    @Arg('offset', { defaultValue: 0 }) offset: number,
+    @Arg('offset', { defaultValue: DEFAULT_OFFSET }) offset: number,
   ) {
     return ArticleRepo.getArticlesByPublicationSlug(slug, limit, offset);
   }
@@ -81,7 +81,7 @@ class ArticleResolver {
   async getArticlesByPublicationSlugs(
     @Arg('slugs', (type) => [String]) slugs: string[],
     @Arg('limit', { defaultValue: DEFAULT_LIMIT }) limit: number,
-    @Arg('offset', { defaultValue: 0 }) offset: number,
+    @Arg('offset', { defaultValue: DEFAULT_OFFSET }) offset: number,
   ) {
     return ArticleRepo.getArticlesByPublicationSlugs(slugs, limit, offset);
   }

--- a/src/resolvers/ArticleResolver.ts
+++ b/src/resolvers/ArticleResolver.ts
@@ -24,10 +24,13 @@ class ArticleResolver {
 
   @Query((_returns) => [Article], {
     nullable: false,
-    description: `Returns a list of <Articles> of size <limit>. Default <limit> is ${DEFAULT_LIMIT}`,
+    description: `Returns a list of <Articles> of size <limit> with offset <offset>. Default <limit> is ${DEFAULT_LIMIT} and default <offset> is 0`,
   })
-  async getAllArticles(@Arg('limit', { defaultValue: DEFAULT_LIMIT }) limit: number) {
-    const articles = await ArticleRepo.getAllArticles(limit);
+  async getAllArticles(
+    @Arg('limit', { defaultValue: DEFAULT_LIMIT }) limit: number,
+    @Arg('offset', { defaultValue: 0 }) offset: number,
+  ) {
+    const articles = await ArticleRepo.getAllArticles(offset, limit);
     return articles;
   }
 
@@ -35,8 +38,12 @@ class ArticleResolver {
     nullable: false,
     description: 'Returns a list of <Articles> via the given <publicationID>',
   })
-  async getArticlesByPublicationID(@Arg('publicationID') publicationID: string) {
-    return ArticleRepo.getArticlesByPublicationID(publicationID);
+  async getArticlesByPublicationID(
+    @Arg('publicationID') publicationID: string,
+    @Arg('limit', { defaultValue: DEFAULT_LIMIT }) limit: number,
+    @Arg('offset', { defaultValue: 0 }) offset: number,
+  ) {
+    return ArticleRepo.getArticlesByPublicationID(publicationID, limit, offset);
   }
 
   @Query((_returns) => [Article], {
@@ -45,24 +52,34 @@ class ArticleResolver {
   })
   async getArticlesByPublicationIDs(
     @Arg('publicationIDs', (type) => [String]) publicationIDs: string[],
+    @Arg('limit', { defaultValue: DEFAULT_LIMIT }) limit: number,
+    @Arg('offset', { defaultValue: 0 }) offset: number,
   ) {
-    return ArticleRepo.getArticlesByPublicationIDs(publicationIDs);
+    return ArticleRepo.getArticlesByPublicationIDs(publicationIDs, limit, offset);
   }
 
   @Query((_returns) => [Article], {
     nullable: false,
     description: 'Returns a list of <Articles> via the given <slug>',
   })
-  async getArticlesByPublicationSlug(@Arg('slug') slug: string) {
-    return ArticleRepo.getArticlesByPublicationSlug(slug);
+  async getArticlesByPublicationSlug(
+    @Arg('slug') slug: string,
+    @Arg('limit', { defaultValue: DEFAULT_LIMIT }) limit: number,
+    @Arg('offset', { defaultValue: 0 }) offset: number,
+  ) {
+    return ArticleRepo.getArticlesByPublicationSlug(slug, limit, offset);
   }
 
   @Query((_returns) => [Article], {
     nullable: false,
     description: 'Returns a list of <Articles> via the given list of <slugs>',
   })
-  async getArticlesByPublicationSlugs(@Arg('slugs', (type) => [String]) slugs: string[]) {
-    return ArticleRepo.getArticlesByPublicationSlugs(slugs);
+  async getArticlesByPublicationSlugs(
+    @Arg('slugs', (type) => [String]) slugs: string[],
+    @Arg('limit', { defaultValue: DEFAULT_LIMIT }) limit: number,
+    @Arg('offset', { defaultValue: 0 }) offset: number,
+  ) {
+    return ArticleRepo.getArticlesByPublicationSlugs(slugs, limit, offset);
   }
 
   @Query((_returns) => [Article], {

--- a/src/resolvers/ArticleResolver.ts
+++ b/src/resolvers/ArticleResolver.ts
@@ -36,7 +36,8 @@ class ArticleResolver {
 
   @Query((_returns) => [Article], {
     nullable: false,
-    description: 'Returns a list of <Articles> via the given <publicationID>',
+    description:
+      'Returns a list of <Articles> of size <limit> via the given <publicationID>. Results can offsetted by <offset> >= 0.',
   })
   async getArticlesByPublicationID(
     @Arg('publicationID') publicationID: string,
@@ -48,7 +49,8 @@ class ArticleResolver {
 
   @Query((_returns) => [Article], {
     nullable: false,
-    description: 'Returns a list of <Articles> via the given list of <publicationIDs>',
+    description:
+      'Returns a list of <Articles> of size <limit> via the given list of <publicationIDs>. Results offsetted by <offset> >= 0.',
   })
   async getArticlesByPublicationIDs(
     @Arg('publicationIDs', (type) => [String]) publicationIDs: string[],
@@ -60,7 +62,8 @@ class ArticleResolver {
 
   @Query((_returns) => [Article], {
     nullable: false,
-    description: 'Returns a list of <Articles> via the given <slug>',
+    description:
+      'Returns a list of <Articles> of size <limit> via the given <slug>. Results can be offsetted by <offset> >= 0.',
   })
   async getArticlesByPublicationSlug(
     @Arg('slug') slug: string,
@@ -72,7 +75,8 @@ class ArticleResolver {
 
   @Query((_returns) => [Article], {
     nullable: false,
-    description: 'Returns a list of <Articles> via the given list of <slugs>',
+    description:
+      'Returns a list of <Articles> of size <limit> via the given list of <slugs>. Results can be offsetted by <offset> >= 0.',
   })
   async getArticlesByPublicationSlugs(
     @Arg('slugs', (type) => [String]) slugs: string[],


### PR DESCRIPTION
## Overview
Adds `offset` and `limit` params to the `getAllArticles`, `getArticlesByPublicationSlug`, `getArticlesByPublicationSlugs`, `getArticlesByPublicationID`, and `getArticlesByPublicationIDs` queries. 

The documentation of each corresponding function has been updated to show that limiting and offsets are supported. Default limit is 25 as specified in `constants.ts`. Default offset is 0, also specified in `constants.ts`.

There are also some invariants/constraints on the limit and offset values:
- Offset >= 0
- Limit > 0
- If offset + limit > articles in DB, the number of articles returned < limit (articles from between offsets `offset` to `max_offset` (inclusive) are returned)
- If offset > articles in DB, an empty list is returned



## Changes Made
- Utilized mongoose's `.skip()` to represent the offset functionality
- Also used `.limit()` for limit in repo functions that didn't have limit before



## Test Coverage
- Ran manual tests on all queries
- Tested `offset + limit < len(articles)1
- Tested `offset > len(articles)`
- Tested `offset + limit > len(articles)`
- Tested `offset = 0`, `limit = 0`
- Tested negative offsets and limits

All tests succeeded with intended behavior according to aforementioned constraints


## Next Steps (delete if not applicable)
- Implementing pagination on iOS/Android