### PR TITLE
Publication Slug Migration

### DIFF
--- a/migrate-mongo-config.js
+++ b/migrate-mongo-config.js
@@ -1,0 +1,36 @@
+// In this file you can configure migrate-mongo
+
+const config = {
+  mongodb: {
+    // TODO Change (or review) the url to your MongoDB:
+    url: "mongodb://localhost:27017",
+
+    // TODO Change this to your database name:
+    databaseName: "volume",
+
+    options: {
+      useNewUrlParser: true, // removes a deprecation warning when connecting
+      useUnifiedTopology: true, // removes a deprecating warning when connecting
+      //   connectTimeoutMS: 3600000, // increase connection timeout to 1 hour
+      //   socketTimeoutMS: 3600000, // increase socket timeout to 1 hour
+    }
+  },
+
+  // The migrations dir, can be an relative or absolute path. Only edit this when really necessary.
+  migrationsDir: "migrations",
+
+  // The mongodb collection where the applied changes are stored. Only edit this when really necessary.
+  changelogCollectionName: "changelog",
+
+  // The file extension to create migrations and search for in migration dir 
+  migrationFileExtension: ".js",
+
+  // Enable the algorithm to create a checksum of the file contents and use that in the comparison to determine
+  // if the file should be run.  Requires that scripts are coded to be run multiple times.
+  useFileHash: false,
+
+  // Don't change this, unless you know what you're doing
+  moduleSystem: 'commonjs',
+};
+
+module.exports = config;

--- a/migrations/add-filter.js
+++ b/migrations/add-filter.js
@@ -1,15 +1,15 @@
 module.exports = {
   async up(db) {
-     /**
-     * Adds the `isFiltered` field to all articles.
-     */
+    /**
+    * Adds the `isFiltered` field to all articles.
+    */
     let Filter = require('../node_modules/bad-words');
-    const filter = new Filter({emptyList: true});
-    filter.addWords('covid-19','coronavirus', 'pandemic','masks','mask','test','testing','tests')
+    const filter = new Filter({ emptyList: true });
+    filter.addWords('covid-19', 'coronavirus', 'pandemic', 'masks', 'mask', 'test', 'testing', 'tests')
     const articles = await db.collection('articles').find({}).toArray();
-    articles.map( async (article) => {
-        await db.collection('articles').updateOne({_id: article._id}, {$set: {isFiltered: filter.isProfane(article.title)}});
-        return article;
+    articles.map(async (article) => {
+      await db.collection('articles').updateOne({ _id: article._id }, { $set: { isFiltered: filter.isProfane(article.title) } });
+      return article;
     });
   },
 
@@ -18,9 +18,9 @@ module.exports = {
      * Reverts the changes to the mongo database.
      */
     const articles = await db.collection('articles').find({}).toArray();
-    articles.map( async (article) => {
-      await db.collection('articles').updateOne({_id: article._id}, {$unset: {isFiltered: ''}});
+    articles.map(async (article) => {
+      await db.collection('articles').updateOne({ _id: article._id }, { $unset: { isFiltered: '' } });
       return article;
     });
-    },
+  },
 };

--- a/migrations/followingSlugs.js
+++ b/migrations/followingSlugs.js
@@ -1,0 +1,31 @@
+module.exports = {
+    async up(db) {
+        /**
+         * Convering user followed publication ids to slugs
+         */
+        const allUsers = await db.collection('users').find({}).toArray();
+        allUsers.forEach(async (user) => {
+            const pubIds = user.followedPublications;
+            await db.collection('users').updateOne({ _id: user._id }, { $set: { followedPublications: [] } });
+            pubIds.forEach(async (id) => {
+                const pubData = await db.collection('publications').findOne({ _id: id })
+                await db.collection('users').updateOne({ _id: user._id }, { $push: { followedPublications: pubData.slug } });
+            });
+        })
+    },
+
+    async down(db) {
+        /**
+         * Convering user followed publication slugs to ids
+         */
+        const allUsers = await db.collection('users').find({}).toArray();
+        allUsers.forEach(async (user) => {
+            const pubSlugs = user.followedPublications;
+            await db.collection('users').updateOne({ _id: user._id }, { $set: { followedPublications: [] } });
+            pubSlugs.forEach(async (slug) => {
+                const pubData = await db.collection('publications').findOne({ slug: slug })
+                await db.collection('users').updateOne({ _id: user._id }, { $push: { followedPublications: pubData._id } });
+            });
+        })
+    }
+}

--- a/migrations/followingSlugs.js
+++ b/migrations/followingSlugs.js
@@ -1,7 +1,7 @@
 module.exports = {
     async up(db) {
         /**
-         * Convering user followed publication ids to slugs
+         * Converting user followed publication ids to slugs
          */
         const allUsers = await db.collection('users').find({}).toArray();
         allUsers.forEach(async (user) => {
@@ -16,7 +16,7 @@ module.exports = {
 
     async down(db) {
         /**
-         * Convering user followed publication slugs to ids
+         * Converting user followed publication slugs to ids
          */
         const allUsers = await db.collection('users').find({}).toArray();
         allUsers.forEach(async (user) => {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -19,3 +19,14 @@ export class PublicationID {
   @Property()
   id: string;
 }
+
+@ObjectType({ description: 'Slug of a Publication' })
+export class PublicationSlug {
+  @Field()
+  @Property()
+  slug: string;
+
+  constructor(slug: string) {
+    this.slug = slug;
+  }
+}

--- a/src/entities/User.ts
+++ b/src/entities/User.ts
@@ -3,7 +3,7 @@ import { prop as Property, DocumentType, getModelForClass } from '@typegoose/typ
 import mongoose from 'mongoose';
 import { Article } from './Article';
 import WeeklyDebrief from './WeeklyDebrief';
-import { PublicationID } from '../common/types';
+import { PublicationSlug } from '../common/types';
 
 @ObjectType({ description: 'The User Model' })
 export class User {
@@ -16,9 +16,9 @@ export class User {
 
   // https://github.com/typegoose/typegoose/issues/522
   // https://github.com/typegoose/typegoose/discussions/380
-  @Field((type) => [PublicationID])
-  @Property({ required: true, type: () => PublicationID, default: [] })
-  followedPublications: mongoose.Types.DocumentArray<DocumentType<PublicationID>>;
+  @Field((type) => [PublicationSlug])
+  @Property({ required: true, type: () => PublicationSlug, default: [] })
+  followedPublications: mongoose.Types.DocumentArray<DocumentType<PublicationSlug>>;
 
   @Field()
   @Property({ unique: true })

--- a/src/repos/UserRepo.ts
+++ b/src/repos/UserRepo.ts
@@ -5,7 +5,7 @@ import { PublicationSlug } from '../common/types';
 import { User, UserModel } from '../entities/User';
 
 /**
- * Create new user associated with deviceToken and followedPublicationsIDs of deviceType.
+ * Create new user associated with deviceToken and followedPublicationsSlugs of deviceType.
  */
 const createUser = async (
   deviceToken: string,
@@ -17,7 +17,7 @@ const createUser = async (
 
   // If no user, create a new one
   if (!users[0]) {
-    // Create PublicationID objects from string of followed publications
+    // Create PublicationSlug objects from string of followed publications
     const followedPublications = followedPublicationsSlugs.map((slug) => new PublicationSlug(slug));
     const uuid = uuidv4();
     const newUser = Object.assign(new User(), {

--- a/src/repos/UserRepo.ts
+++ b/src/repos/UserRepo.ts
@@ -34,7 +34,7 @@ const createUser = async (
 };
 
 /**
- * Adds publication of pubID to user represented by uuid's followedPublications.
+ * Adds publication slug to user's followedPublications.
  */
 const followPublication = async (uuid: string, slug: string): Promise<User> => {
   const user = await UserModel.findOne({ uuid });
@@ -47,13 +47,13 @@ const followPublication = async (uuid: string, slug: string): Promise<User> => {
 };
 
 /**
- * Deletes publication of pubID from user represented by uuid's followedPublications.
+ * Deletes publication slug from user's followedPublications.
  */
 const unfollowPublication = async (uuid: string, pubSlug: string): Promise<User> => {
   const user = await UserModel.findOne({ uuid });
   if (user) {
-    const pubIDs = user.followedPublications.map((pubSlugObj) => pubSlugObj.slug);
-    const pubIndex = pubIDs.indexOf(pubSlug);
+    const pubSlugs = user.followedPublications.map((pubSlugObj) => pubSlugObj.slug);
+    const pubIndex = pubSlugs.indexOf(pubSlug);
 
     if (pubIndex === -1) return user;
 

--- a/src/resolvers/UserResolver.ts
+++ b/src/resolvers/UserResolver.ts
@@ -15,31 +15,31 @@ class UserResolver {
   }
 
   @Mutation((_returns) => User, {
-    description: `Creates a single <User> via given <deviceToken>, <followedPublications>,
+    description: `Creates a single <User> via given <deviceToken>, <followedPublications> (slugs),
    and <deviceType>. Given <deviceToken> must be unique for a new user to be created, otherwise does nothing.`,
   })
   async createUser(
     @Arg('deviceToken') deviceToken: string,
-    @Arg('followedPublications', (type) => [String]) followedPublicationsIDs: string[],
+    @Arg('followedPublications', (type) => [String]) followedPublicationsSlugs: string[],
     @Arg('deviceType') deviceType: string,
   ) {
-    return await UserRepo.createUser(deviceToken, followedPublicationsIDs, deviceType);
+    return await UserRepo.createUser(deviceToken, followedPublicationsSlugs, deviceType);
   }
 
   @Mutation((_returns) => User, {
     nullable: true,
-    description: 'Lets the user from a given <uuid> follow the <Publication> given by <pubID>',
+    description: 'User with id <uuid> follows the <Publication> referenced by <slug>',
   })
-  async followPublication(@Arg('uuid') uuid: string, @Arg('pubID') pubID: string) {
-    return await UserRepo.followPublication(uuid, pubID);
+  async followPublication(@Arg('uuid') uuid: string, @Arg('slug') slug: string) {
+    return await UserRepo.followPublication(uuid, slug);
   }
 
   @Mutation((_returns) => User, {
     nullable: true,
-    description: 'Lets the user from a given <uuid> unfollow the <Publication> given by <pubID>',
+    description: 'User with id <uuid> unfollows the <Publication> referenced by <slug>',
   })
-  async unfollowPublication(@Arg('uuid') uuid: string, @Arg('pubID') pubID: string) {
-    return await UserRepo.unfollowPublication(uuid, pubID);
+  async unfollowPublication(@Arg('uuid') uuid: string, @Arg('slug') slug: string) {
+    return await UserRepo.unfollowPublication(uuid, slug);
   }
 
   @Mutation((_returns) => User, {


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview
This PR migrates the `followPublication` and `unfollowPublication` to slugs rather than ids and thus fully deprecates `PublicationId`s in the backend codebase. Our reasoning for this decision was as follows:
- **Background:** Initially, all publications were uniquely identified by the id hash that MongoDB automatically generates for any new document
- **Situation:** It was really hard to debug across local, dev, and prod servers using this system, seeing as publishers had different ids on **every single DB**. We needed to figure out a better way to identify publishers uniquely across all databases
- **Decision:** Slugs (short unique strings to identify each publisher) had already been implemented in prior semesters, and we had partially transitioned to them. We decided to fully transition all publication references to slugs in order to phase out IDs once and for all and resolve issues caused by mixing IDs and slugs



## Changes Made
Removed the `PublicationId` class and replaced it with `PublicationSlug`, seeing as the class wasn't being used anywhere besides these mutations. Also wrote `followingSlugs.js` migration to be used by migrate-mongo to move existing users which have publication ids stored in their `followedPublications` field to storing publication slugs instead.


## Test Coverage

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->
Utilized GraphQL playground to create a user, add some default publications using slugs, and then also test out the `followPublication` and `unfollowPublication` mutations. See screenshots of tests below:

<img width="1511" alt="Screen Shot 2022-09-29 at 10 57 30 AM" src="https://user-images.githubusercontent.com/22649594/193068942-2198af04-daec-4a44-a364-a0fd2d208a12.png">
<img width="1512" alt="Screen Shot 2022-09-29 at 10 57 35 AM" src="https://user-images.githubusercontent.com/22649594/193068999-ec383da4-fe8e-4dc5-b768-c329d9867a3f.png">
<img width="1510" alt="Screen Shot 2022-09-29 at 11 03 35 AM" src="https://user-images.githubusercontent.com/22649594/193069048-91d7621d-78a1-4e1a-910b-33a4acd7a0e4.png">
<img width="1512" alt="Screen Shot 2022-09-29 at 11 04 09 AM" src="https://user-images.githubusercontent.com/22649594/193069085-dc2b0292-ebde-4c8a-924f-93c32e9b7114.png">

Additionally, tested the migration by running it on the local database and ensuring that all following publication ids were converted to slugs and vice versa. Ran the commands via `migrate-mongo up followingSlugs` and `migrate-mongo down followingSlugs`. Upon migrating up and down, I used `mongosh` to interact with the local mongodb server and ensure documents had been updated as expected.


## Next Steps

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->
If necessary, we might move from just storing publication slugs to an entire subdocument within `followedPublications` if this provides a speedup to frontend. As of now based on my current understanding this wouldn't actually make a difference so will make another quick PR for that if it's necessary.