### PR TITLE
Implement fuse fuzzy searching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "class-validator": "^0.12.2",
         "express": "^4.17.1",
         "firebase-admin": "^9.7.0",
+        "fuse.js": "^6.6.2",
         "graphql": "^15.5.0",
         "mockdate": "^3.0.2",
         "mongodb": "^3.6.2",
@@ -3618,6 +3619,14 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "devOptional": true
+    },
+    "node_modules/fuse.js": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
+      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/gaxios": {
       "version": "4.2.1",
@@ -11621,6 +11630,11 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "devOptional": true
+    },
+    "fuse.js": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
+      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA=="
     },
     "gaxios": {
       "version": "4.2.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "class-validator": "^0.12.2",
     "express": "^4.17.1",
     "firebase-admin": "^9.7.0",
+    "fuse.js": "^6.6.2",
     "graphql": "^15.5.0",
     "mockdate": "^3.0.2",
     "mongodb": "^3.6.2",

--- a/src/repos/ArticleRepo.ts
+++ b/src/repos/ArticleRepo.ts
@@ -1,5 +1,6 @@
 import Filter from 'bad-words';
 import { ObjectId } from 'mongodb';
+import Fuse from 'fuse.js';
 import { Article, ArticleModel } from '../entities/Article';
 import {
   DEFAULT_LIMIT,
@@ -120,6 +121,24 @@ const getArticlesAfterDate = async (since: string, limit = DEFAULT_LIMIT): Promi
 };
 
 /**
+ * Performs fuzzy search on all articles to find articles with title/publisher matching the query.
+ * @param query the term to search for
+ * @param limit the number of results to return
+ * @returns at most limit articles with titles or publishers matching the query
+ */
+const searchArticles = async (query: string, limit = DEFAULT_LIMIT) => {
+  const allArticles = await ArticleModel.find({});
+  const searcher = new Fuse(allArticles, {
+    keys: ['title', 'publication.name'],
+  });
+
+  return searcher
+    .search(query)
+    .map((searchRes) => searchRes.item)
+    .slice(0, limit);
+};
+
+/**
  * Computes and returns the trending articles in the database.
  *
  * @function
@@ -198,6 +217,7 @@ export default {
   getArticlesByPublicationIDs,
   getArticlesByPublicationSlug,
   getArticlesByPublicationSlugs,
+  searchArticles,
   getTrendingArticles,
   incrementShoutouts,
   refreshTrendingArticles,

--- a/src/resolvers/ArticleResolver.ts
+++ b/src/resolvers/ArticleResolver.ts
@@ -106,6 +106,17 @@ class ArticleResolver {
     return ArticleRepo.getTrendingArticles(limit);
   }
 
+  @Query((_returns) => [Article], {
+    nullable: false,
+    description: `Returns a list of <Articles> of size <limit> matches a particular query. Default <limit> is ${DEFAULT_LIMIT}`,
+  })
+  async searchArticles(
+    @Arg('query') query: string,
+    @Arg('limit', { defaultValue: DEFAULT_LIMIT }) limit: number,
+  ) {
+    return ArticleRepo.searchArticles(query, limit);
+  }
+
   @FieldResolver((_returns) => Number, { description: 'The trendiness score of an <Article>' })
   async trendiness(@Root() article: Article): Promise<number> {
     const presentDate = new Date().getTime();


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->
Implemented fuzzy searching query that enables us to search by either publisher or article title. The algorithm intelligently determines when someone is trying to search for a publisher or a particular article title/topic


## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->
- Added fuse.js library
- Implemented fuse library on an article's title and publisher name fields
- Add limit param to limit number of results for frontend

## Test Coverage

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->
Manually tested querying with article titles, article publishers, article titles + publishers ('football nooz' for example, which should yield football articles from cunooz). Each query worked as expected.

## Screenshots (delete if not applicable)
<img width="1512" alt="Screen Shot 2022-10-12 at 5 42 36 PM" src="https://user-images.githubusercontent.com/22649594/195453516-8c0e9f0f-8f6c-44b4-abf4-9dd9ab8a23c3.png">
<img width="1504" alt="Screen Shot 2022-10-12 at 5 42 52 PM" src="https://user-images.githubusercontent.com/22649594/195453555-ee4eedac-157e-41e8-8f17-a70fde7db7d6.png">
<img width="1512" alt="Screen Shot 2022-10-12 at 5 43 03 PM" src="https://user-images.githubusercontent.com/22649594/195453601-c6780102-1589-4842-98f7-859d5a26563b.png">
