### PR TITLE
Add differentiation between iOS and Android notifs

### DIFF
--- a/src/repos/NotificationRepo.ts
+++ b/src/repos/NotificationRepo.ts
@@ -17,18 +17,33 @@ const sendNewArticleNotification = async (
   const notifTitle = publication.name;
   const notifBody = article.title;
 
-  const message = {
-    notification: {
-      title: notifTitle,
-      body: notifBody,
-    },
-    data: {
-      userID: user.uuid,
-      articleID: article.id,
-      articleURL: article.articleURL,
-      notificationType: 'new_article',
-    },
+  const notifData = {
+    title: notifTitle,
+    body: notifBody,
   };
+
+  const metaData = {
+    userID: user.uuid,
+    articleID: article.id,
+    articleURL: article.articleURL,
+    notificationType: 'new_article',
+  };
+
+  let message = {};
+
+  if (user.deviceType === 'IOS') {
+    message = {
+      notification: notifData,
+      data: metaData,
+    };
+  } else {
+    message = {
+      data: {
+        ...notifData,
+        ...metaData,
+      },
+    };
+  }
 
   const options = {
     priority: 'high',

--- a/src/repos/NotificationRepo.ts
+++ b/src/repos/NotificationRepo.ts
@@ -8,14 +8,22 @@ import ArticleRepo from './ArticleRepo';
 import { Magazine } from '../entities/Magazine';
 import MagazineRepo from './MagazineRepo';
 
-const sendNewArticleNotification = async (
+/**
+ * General purpose function for sending notifications.
+ * @param user User object
+ * @param notifTitle Notification title
+ * @param notifBody Notificiation body
+ * @param uniqueData Any unique metadata to be sent in notif beyond uuid and notif type
+ * @param notifType Notification type (ex. 'new_article')
+ */
+const sendNotif = async (
   user: User,
-  article: Article,
-  publication: Publication,
-): Promise<void> => {
+  notifTitle: string,
+  notifBody: string,
+  uniqueData: Record<string, string>,
+  notifType: string,
+) => {
   const { deviceToken } = user;
-  const notifTitle = publication.name;
-  const notifBody = article.title;
 
   const notifData = {
     title: notifTitle,
@@ -24,13 +32,13 @@ const sendNewArticleNotification = async (
 
   const metaData = {
     userID: user.uuid,
-    articleID: article.id,
-    articleURL: article.articleURL,
-    notificationType: 'new_article',
+    ...uniqueData,
+    notificationType: notifType,
   };
 
   let message = {};
 
+  // Determine notif format based on device type
   if (user.deviceType === 'IOS') {
     message = {
       notification: notifData,
@@ -62,6 +70,22 @@ const sendNewArticleNotification = async (
     });
 };
 
+const sendNewArticleNotification = async (
+  user: User,
+  article: Article,
+  publication: Publication,
+): Promise<void> => {
+  const notifTitle = publication.name;
+  const notifBody = article.title;
+
+  const uniqueData = {
+    articleID: article.id,
+    articleURL: article.articleURL,
+  };
+
+  sendNotif(user, notifTitle, notifBody, uniqueData, 'new_article');
+};
+
 /**
  * Send notifications for new articles have been posted by publications.
  */
@@ -81,39 +105,15 @@ const sendNewMagazineNotification = async (
   magazine: Magazine,
   publication: Publication,
 ): Promise<void> => {
-  const { deviceToken } = user;
-
   const notifTitle = publication.name;
   const notifBody = magazine.title;
 
-  const message = {
-    notification: {
-      title: notifTitle,
-      body: notifBody,
-    },
-    data: {
-      userID: user.uuid,
-      magazineID: magazine.id,
-      magazinePDF: magazine.pdfURL,
-      notificationType: 'new_magazine',
-    },
+  const uniqueData = {
+    magazineID: magazine.id,
+    magazinePDF: magazine.pdfURL,
   };
 
-  const options = {
-    priority: 'high',
-    timeToLive: 60 * 60 * 24,
-  };
-
-  // Send notification to FCM servers
-  admin
-    .messaging()
-    .sendToDevice(deviceToken, message, options)
-    .then((response) => {
-      console.log(response);
-    })
-    .catch((error) => {
-      console.log(error);
-    });
+  sendNotif(user, notifTitle, notifBody, uniqueData, 'new_magazine');
 };
 
 /**
@@ -131,38 +131,10 @@ const notifyNewMagazines = async (magazineIDs: string[]): Promise<void> => {
 };
 
 const sendWeeklyDebriefNotification = async (user: User): Promise<void> => {
-  // Get device token of user
-  const { deviceToken } = user;
-
   const notifTitle = 'Your Weekly Debrief is Ready';
   const notifBody = 'Click to check out whats new on Volume this week!';
 
-  const message = {
-    notification: {
-      title: notifTitle,
-      body: notifBody,
-    },
-    data: {
-      userID: user.uuid,
-      notifcationType: 'weekly_debrief',
-    },
-  };
-
-  const options = {
-    priority: 'high',
-    timeToLive: 60 * 60 * 24,
-  };
-
-  // Send notification to FCM servers
-  admin
-    .messaging()
-    .sendToDevice(deviceToken, message, options)
-    .then((response) => {
-      console.log(response);
-    })
-    .catch((error) => {
-      console.log(error);
-    });
+  sendNotif(user, notifTitle, notifBody, {}, 'weekly_debrief');
 };
 
 /**


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->
This PR creates separate notif types for both android and iOS based on a user's device type, as requested by the android subteam (because android needs a different data format than what we're sending to iOS).

It also factors out all duplicated code across various notification functions and centralizes them in a single `sendNotif` function to increase maintainability in the future and convert all notification types to the new format for android notifs.

## Changes Made
- Use user's device type in order to determine what type of notif to send
- Factor out notif code to prevent code duplication using JS spread syntax (the ... operator)


## Test Coverage
I first modified just the article notif function and ensured that the objects were constructed properly by testing with dummy values, since that's the only thing that was changed. I then factored out the code and ensured that the data being sent was the same as before.

Also asked Kidus & Ben to pull & try sending notifs on iOS/android, which worked