### PR TITLE
Convert result of shuffling resolver to ArticleModel

### DIFF
--- a/src/repos/ArticleRepo.ts
+++ b/src/repos/ArticleRepo.ts
@@ -130,14 +130,14 @@ const getShuffledArticlesByPublicationSlugs = async (
       },
     },
   ]).then((articles) => {
-    const articlesByPub = {};
-    for (const article of articles) {
-      articlesByPub[article._id] = article.articles.filter(
+    const filteredArticles = {};
+    for (const a of articles) {
+      filteredArticles[a._id] = a.articles.filter(
         (article) => article !== null && !isArticleFiltered(article),
       );
-      mostByOnePub = Math.max(mostByOnePub, articlesByPub[article._id].length);
+      mostByOnePub = Math.max(mostByOnePub, filteredArticles[a._id].length);
     }
-    return articlesByPub;
+    return filteredArticles;
   });
 
   // take the ith element from each array in articlesByPub, add it to a list named ithArticles,
@@ -148,7 +148,7 @@ const getShuffledArticlesByPublicationSlugs = async (
     const ithArticles = [];
     for (const key of Object.keys(articlesByPub)) {
       if (articlesByPub[key][i]) {
-        ithArticles.push(articlesByPub[key][i]);
+        ithArticles.push(new ArticleModel(articlesByPub[key][i])); // convert each article json object back to an ArticleModel object.
       }
     }
     ithArticles.sort((a, b) => {
@@ -156,7 +156,6 @@ const getShuffledArticlesByPublicationSlugs = async (
     });
     shuffledArticles.push(...ithArticles);
   }
-
   return shuffledArticles;
 };
 


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

I removed shadowing variables and fixed the functionality of the getShuffledArticlesByPublicationSlugs

MongoDB's aggregate functionality returns a json object, which does not contain the proper ID field (it contains _id without the getter needed to resolve from a GraphQL query). This caused queries to fail. 


## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->
To fix the null id results in GraphQL queries, I converted each article JSON back into an ArticleModel object using the ArticleModel() constructor.


## Test Coverage

I tested that queries containing the article's ID and the nested publication's ID returned the expected result. I used console.log to view the articles before they were returned.

## Next Steps (delete if not applicable)
It may be worth it to refactor the getShuffledArticlesByPublicationSlugs function in ArticleRepos to use multiple .find queries rather than .aggregate to avoid the conversion to JSON and back to ArticleModel. This will also match the pattern of other functions and have less potential for unexpected behavior. However, this seems to work for now.

## Related PRs or Issues (delete if not applicable)
#68
<!-- List related PRs against other branches/repositories. -->



