### PR TITLE
Add imageURL field to Magazine entity.

### DIFF
--- a/src/entities/Magazine.ts
+++ b/src/entities/Magazine.ts
@@ -19,6 +19,10 @@ export class Magazine {
   @Property()
   pdfURL: string;
 
+  @Field()
+  @Property()
+  imageURL: string;
+
   @Field((type) => Publication)
   @Property({ type: () => Publication })
   publication: Publication;


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

Add imageURL field to Magazine entity, following the pdfURL template (non nullable string).



## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->



## Test Coverage

I checked that when the micro service was run (volume-microservice PR 22), the graphql queries containing the new imageURL worked and that the database was updated properly.


## Related PRs or Issues (delete if not applicable)

PR 22 in volume-microservice (interdependent PRs)

File size issue is related as it would affect the same methods.


## Screenshots (delete if not applicable)


<img width="1440" alt="Screen Shot 2023-04-03 at 9 42 08 PM" src="https://user-images.githubusercontent.com/104698418/229667161-0647b399-732f-47d8-915d-32144d4d752b.png">


  <summary>Working GraphQL query with imageURL field</summary>

<img width="1440" alt="Screen Shot 2023-04-03 at 9 35 58 PM" src="https://user-images.githubusercontent.com/104698418/229666701-f959d95a-2cbf-4a78-97bf-fb1f5b6155cb.png">


  <summary>Magazine with imageURL field added to db (required new volume-backend pr 73 to run)</summary>

