### PR TITLE
Fixed notification issue

### DIFF
--- a/src/repos/NotificationRepo.ts
+++ b/src/repos/NotificationRepo.ts
@@ -59,15 +59,17 @@ const sendNotif = async (
   };
 
   // Send notification to FCM servers
-  admin
-    .messaging()
-    .sendToDevice(deviceToken, message, options)
-    .then((response) => {
-      console.log(response);
-    })
-    .catch((error) => {
-      console.log(error);
-    });
+  if (deviceToken !== '') {
+    admin
+      .messaging()
+      .sendToDevice(deviceToken, message, options)
+      .then((response) => {
+        console.log(response);
+      })
+      .catch((error) => {
+        console.log(error);
+      });
+  }
 };
 
 const sendNewArticleNotification = async (


### PR DESCRIPTION
## Overview
Fixed notification issue where weekly debrief reminders were not being sent as well as new articles and magazines from publications.

## Changes Made
- Required that the device token cannot be an empty string when sending the notification using FCM.


## Test Coverage
- The best way to pinpoint the issue was to clone the database in the prod server onto my local database. Once I did that, I configured my environment variables to point to my local database. Sending the notification with the HTTP request showed an error indicating that the device token sent using FCM was an empty string (see screenshot below). It seems like at least one user in the database did not have a device token causing the entire call to fail and not reach the other users. There is another way to send a notification using FCM that is able to accept the empty string, but the best way to fix this without changing the current code is to only send the notification if it's non-empty. Tested it and it immediately worked. This should also fix the issue for weekly debrief as well since they all rely on this one function call to send the notification. Since my local database is an exact clone of prod, the notification was sent directly to my device, so we can assume that this should work on prod.

## Next Steps
- There could be other issues causing notifications to not send, but this is one potential cause.

## Screenshots
<img width="998" alt="Screenshot 2023-08-22 at 12 35 35 AM" src="https://github.com/cuappdev/volume-backend/assets/75594943/4933391b-6823-42db-8814-39aee631ed54">
