### PR TITLE
Flyer Notifications + Org/Flyer Model Changes

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -3,8 +3,6 @@ name: Docker Build & Push and Deploy to volume-backend
 on:
   push:
     branches: [release]
-  pull_request:
-    branches: [release]
 
 jobs:
   path-context:

--- a/src/app.ts
+++ b/src/app.ts
@@ -66,6 +66,12 @@ const main = async () => {
     res.json({ success: 'true' });
   });
 
+  app.post('/collect/flyers/', (req, res) => {
+    const { flyerIDs } = req.body;
+    NotificationRepo.notifyNewFlyers(flyerIDs);
+    res.json({ success: 'true' });
+  });
+
   server.applyMiddleware({ app });
 
   async function setupWeeklyDebriefRefreshCron() {

--- a/src/entities/Flyer.ts
+++ b/src/entities/Flyer.ts
@@ -9,11 +9,15 @@ export class Flyer {
 
   @Field()
   @Property()
-  endDate: Date;
+  categorySlug: string;
 
   @Field()
-  @Property({ nullable: true })
-  flyerURL: string;
+  @Property()
+  endDate: Date;
+
+  @Field({ nullable: true })
+  @Property()
+  flyerURL?: string;
 
   @Field()
   @Property()
@@ -27,17 +31,13 @@ export class Flyer {
   @Property()
   location: string;
 
+  @Field((type) => Organization)
+  @Property({ type: () => Organization })
+  organization: Organization;
+
   @Field()
-  @Property({ default: false })
-  nsfw: boolean;
-
-  @Field((type) => [Organization])
-  @Property({ type: () => [Organization] })
-  organizations: [Organization];
-
-  @Field((type) => [String])
-  @Property({ type: () => [String] })
-  organizationSlugs: [string];
+  @Property()
+  organizationSlug: string;
 
   @Field()
   @Property()

--- a/src/entities/Organization.ts
+++ b/src/entities/Organization.ts
@@ -6,13 +6,13 @@ export class Organization {
   @Field(() => ID)
   id: string;
 
-  @Field()
-  @Property({ nullable: true })
-  backgroundImageURL: string;
+  @Field({ nullable: true })
+  @Property()
+  backgroundImageURL?: string;
 
-  @Field()
-  @Property({ nullable: true })
-  bio: string;
+  @Field({ nullable: true })
+  @Property()
+  bio?: string;
 
   @Field()
   @Property()
@@ -22,9 +22,9 @@ export class Organization {
   @Property()
   name: string;
 
-  @Field()
-  @Property({ nullable: true })
-  profileImageURL: string;
+  @Field({ nullable: true })
+  @Property()
+  profileImageURL?: string;
 
   @Field()
   @Property()
@@ -35,7 +35,7 @@ export class Organization {
   shoutouts?: number;
 
   @Field()
-  @Property({ nullable: true })
+  @Property()
   websiteURL: string;
 }
 

--- a/src/repos/FlyerRepo.ts
+++ b/src/repos/FlyerRepo.ts
@@ -84,7 +84,7 @@ const getFlyersByOrganizationSlug = async (
   limit: number = DEFAULT_LIMIT,
   offset: number = DEFAULT_OFFSET,
 ): Promise<Flyer[]> => {
-  return FlyerModel.find({ organizationSlugs: slug })
+  return FlyerModel.find({ 'organization.slug': slug })
     .sort({ startDate: 'desc' })
     .skip(offset)
     .limit(limit)
@@ -99,7 +99,7 @@ const getFlyersByOrganizationSlugs = async (
   offset: number = DEFAULT_OFFSET,
 ): Promise<Flyer[]> => {
   const uniqueSlugs = [...new Set(slugs)];
-  return FlyerModel.find({ organizationSlugs: { $in: uniqueSlugs } })
+  return FlyerModel.find({ 'organization.slug': { $in: uniqueSlugs } })
     .sort({ startDate: 'desc' })
     .skip(offset)
     .limit(limit)

--- a/src/repos/NotificationRepo.ts
+++ b/src/repos/NotificationRepo.ts
@@ -1,9 +1,4 @@
 import * as admin from 'firebase-admin';
-import { Article } from '../entities/Article';
-import { Flyer } from '../entities/Flyer';
-import { Magazine } from '../entities/Magazine';
-import { Organization } from '../entities/Organization';
-import { Publication } from '../entities/Publication';
 import { User } from '../entities/User';
 import ArticleRepo from './ArticleRepo';
 import FlyerRepo from './FlyerRepo';
@@ -76,22 +71,6 @@ const sendNotif = async (
   }
 };
 
-const sendNewArticleNotification = async (
-  user: User,
-  article: Article,
-  publication: Publication,
-): Promise<void> => {
-  const notifTitle = publication.name;
-  const notifBody = article.title;
-
-  const uniqueData = {
-    articleID: article.id,
-    articleURL: article.articleURL,
-  };
-
-  sendNotif(user, notifTitle, notifBody, uniqueData, 'new_article');
-};
-
 /**
  * Send notifications for new articles have been posted by publications.
  */
@@ -101,25 +80,17 @@ const notifyNewArticles = async (articleIDs: string[]): Promise<void> => {
     const publication = await PublicationRepo.getPublicationBySlug(article.publicationSlug);
     const followers = await UserRepo.getUsersFollowingPublication(article.publicationSlug);
     followers.forEach(async (follower) => {
-      sendNewArticleNotification(follower, article, publication);
+      const notifTitle = publication.name;
+      const notifBody = article.title;
+
+      const uniqueData = {
+        articleID: article.id,
+        articleURL: article.articleURL,
+      };
+
+      await sendNotif(follower, notifTitle, notifBody, uniqueData, 'new_article');
     });
   });
-};
-
-const sendNewMagazineNotification = async (
-  user: User,
-  magazine: Magazine,
-  publication: Publication,
-): Promise<void> => {
-  const notifTitle = publication.name;
-  const notifBody = magazine.title;
-
-  const uniqueData = {
-    magazineID: magazine.id,
-    magazinePDF: magazine.pdfURL,
-  };
-
-  sendNotif(user, notifTitle, notifBody, uniqueData, 'new_magazine');
 };
 
 /**
@@ -131,25 +102,17 @@ const notifyNewMagazines = async (magazineIDs: string[]): Promise<void> => {
     const publication = await PublicationRepo.getPublicationBySlug(magazine.publicationSlug);
     const followers = await UserRepo.getUsersFollowingPublication(magazine.publicationSlug);
     followers.forEach(async (follower) => {
-      sendNewMagazineNotification(follower, magazine, publication);
+      const notifTitle = publication.name;
+      const notifBody = magazine.title;
+
+      const uniqueData = {
+        magazineID: magazine.id,
+        magazinePDF: magazine.pdfURL,
+      };
+
+      await sendNotif(follower, notifTitle, notifBody, uniqueData, 'new_magazine');
     });
   });
-};
-
-const sendNewFlyerNotification = async (
-  user: User,
-  flyer: Flyer,
-  organization: Organization,
-): Promise<void> => {
-  const notifTitle = organization.name;
-  const notifBody = flyer.title;
-
-  const uniqueData = {
-    flyerID: flyer.id,
-    flyerURL: flyer.flyerURL,
-  };
-
-  sendNotif(user, notifTitle, notifBody, uniqueData, 'new_flyer');
 };
 
 /**
@@ -161,16 +124,17 @@ const notifyNewFlyers = async (flyerIDs: string[]): Promise<void> => {
     const organization = await OrganizationRepo.getOrganizationBySlug(flyer.organizationSlug);
     const followers = await UserRepo.getUsersFollowingOrganization(flyer.organizationSlug);
     followers.forEach(async (follower) => {
-      sendNewFlyerNotification(follower, flyer, organization);
+      const notifTitle = organization.name;
+      const notifBody = flyer.title;
+
+      const uniqueData = {
+        flyerID: flyer.id,
+        flyerURL: flyer.flyerURL,
+      };
+
+      await sendNotif(follower, notifTitle, notifBody, uniqueData, 'new_flyer');
     });
   });
-};
-
-const sendWeeklyDebriefNotification = async (user: User): Promise<void> => {
-  const notifTitle = 'Your Weekly Debrief is Ready';
-  const notifBody = 'Click to check out whats new on Volume this week!';
-
-  sendNotif(user, notifTitle, notifBody, {}, 'weekly_debrief');
 };
 
 /**
@@ -178,15 +142,16 @@ const sendWeeklyDebriefNotification = async (user: User): Promise<void> => {
  */
 const notifyWeeklyDebrief = async (users: User[]): Promise<void> => {
   users.forEach(async (user) => {
-    sendWeeklyDebriefNotification(user);
+    const notifTitle = 'Your Weekly Debrief is Ready';
+    const notifBody = 'Click to check out whats new on Volume this week!';
+
+    await sendNotif(user, notifTitle, notifBody, {}, 'weekly_debrief');
   });
 };
+
 export default {
-  sendNewArticleNotification,
-  sendNewMagazineNotification,
-  sendWeeklyDebriefNotification,
   notifyNewArticles,
-  notifyNewMagazines,
   notifyNewFlyers,
+  notifyNewMagazines,
   notifyWeeklyDebrief,
 };

--- a/src/repos/NotificationRepo.ts
+++ b/src/repos/NotificationRepo.ts
@@ -158,12 +158,10 @@ const sendNewFlyerNotification = async (
 const notifyNewFlyers = async (flyerIDs: string[]): Promise<void> => {
   flyerIDs.forEach(async (f) => {
     const flyer = await FlyerRepo.getFlyerByID(f); // eslint-disable-line
-    flyer.organizationSlugs.forEach(async (slug) => {
-      const organization = await OrganizationRepo.getOrganizationBySlug(slug);
-      const followers = await UserRepo.getUsersFollowingOrganization(slug);
-      followers.forEach(async (follower) => {
-        sendNewFlyerNotification(follower, flyer, organization);
-      });
+    const organization = await OrganizationRepo.getOrganizationBySlug(flyer.organizationSlug);
+    const followers = await UserRepo.getUsersFollowingOrganization(flyer.organizationSlug);
+    followers.forEach(async (follower) => {
+      sendNewFlyerNotification(follower, flyer, organization);
     });
   });
 };

--- a/src/repos/OrganizationRepo.ts
+++ b/src/repos/OrganizationRepo.ts
@@ -66,7 +66,7 @@ const getMostRecentFlyer = async (organization: Organization): Promise<Flyer> =>
   // Due to the way Mongo interprets 'Organization' object,
   // Organization['_doc'] must be used to access fields of a Organization object
   return FlyerModel.findOne({
-    organizationSlugs: organization['_doc'].slug, // eslint-disable-line
+    organizationSlug: organization['_doc'].slug, // eslint-disable-line
   }).sort({ startDate: 'desc' });
 };
 
@@ -80,7 +80,7 @@ const getClicks = async (organization: Organization): Promise<number> => {
   // Due to the way Mongo interprets 'Organization' object,
   // Organization['_doc'] must be used to access fields of a Organization object
   const orgFlyers = await FlyerModel.find({
-    organizationSlugs: organization['_doc'].slug, // eslint-disable-line
+    organizationSlug: organization['_doc'].slug, // eslint-disable-line
   });
 
   return orgFlyers.reduce((acc, flyer) => {
@@ -98,7 +98,7 @@ const getNumFlyers = async (organization: Organization): Promise<number> => {
   // Due to the way Mongo interprets 'Organization' object,
   // Organization['_doc'] must be used to access fields of a Organization object
   const orgFlyers = await FlyerModel.find({
-    organizationSlugs: organization['_doc'].slug, // eslint-disable-line
+    organizationSlug: organization['_doc'].slug, // eslint-disable-line
   });
 
   return orgFlyers.length;

--- a/src/resolvers/OrganizationResolver.ts
+++ b/src/resolvers/OrganizationResolver.ts
@@ -1,5 +1,4 @@
 import { Arg, Resolver, Query, FieldResolver, Root } from 'type-graphql';
-import { Flyer } from '../entities/Flyer';
 import { Organization } from '../entities/Organization';
 import OrganizationRepo from '../repos/OrganizationRepo';
 
@@ -42,21 +41,6 @@ class OrganizationResolver {
   })
   async getOrganizationBySlug(@Arg('slug') slug: string) {
     return OrganizationRepo.getOrganizationBySlug(slug);
-  }
-
-  @FieldResolver((_returns) => Flyer, {
-    nullable: true,
-    description: 'Returns the most recent <Flyer> of an <Organization>',
-  })
-  async mostRecentFlyer(@Root() organization: Organization): Promise<Flyer> {
-    return OrganizationRepo.getMostRecentFlyer(organization);
-  }
-
-  @FieldResolver((_returns) => Number, {
-    description: 'Returns the total number of <Flyers> from an <Organization>',
-  })
-  async numFlyers(@Root() organization: Organization): Promise<number> {
-    return OrganizationRepo.getNumFlyers(organization);
   }
 
   @FieldResolver((_returns) => Number, {

--- a/src/tests/data/FlyerFactory.ts
+++ b/src/tests/data/FlyerFactory.ts
@@ -47,17 +47,17 @@ class FlyerFactory {
     const fakeFlyer = new Flyer();
     const exampleOrg = await OrganizationFactory.getRandomOrganization();
 
-    fakeFlyer.startDate = faker.date.past();
+    fakeFlyer.categorySlug = faker.commerce.productDescription();
     fakeFlyer.endDate = faker.date.future();
-    fakeFlyer.imageURL = faker.image.cats();
     fakeFlyer.flyerURL = faker.datatype.string();
-    fakeFlyer.location = faker.datatype.string();
-    fakeFlyer.organizations = [exampleOrg];
-    fakeFlyer.organizationSlugs = [exampleOrg.slug];
-    fakeFlyer.title = faker.commerce.productDescription();
+    fakeFlyer.imageURL = faker.image.cats();
     fakeFlyer.isTrending = _.sample([true, false]);
-    fakeFlyer.nsfw = _.sample([true, false]);
+    fakeFlyer.location = faker.datatype.string();
+    fakeFlyer.organization = exampleOrg;
+    fakeFlyer.organizationSlug = exampleOrg.slug;
+    fakeFlyer.startDate = faker.date.past();
     fakeFlyer.timesClicked = _.random(0, 50);
+    fakeFlyer.title = faker.commerce.productDescription();
     fakeFlyer.trendiness = 0;
 
     return fakeFlyer;

--- a/src/tests/flyer.test.ts
+++ b/src/tests/flyer.test.ts
@@ -88,8 +88,8 @@ describe('getFlyersByOrganizationSlug(s) tests', () => {
   test('getFlyersByOrganizationSlug - 1 organization, 1 flyer', async () => {
     const org = await OrganizationFactory.getRandomOrganization();
     const flyers = await FlyerFactory.createSpecific(1, {
-      organizationSlugs: [org.slug],
-      organization: [org],
+      organizationSlug: org.slug,
+      organization: org,
     });
     await FlyerModel.insertMany(flyers);
 
@@ -101,8 +101,8 @@ describe('getFlyersByOrganizationSlug(s) tests', () => {
     const org = await OrganizationFactory.getRandomOrganization();
     const flyers = (
       await FlyerFactory.createSpecific(3, {
-        organizationSlugs: [org.slug],
-        organizations: [org],
+        organizationSlug: org.slug,
+        organization: org,
       })
     ).sort(FactoryUtils.compareByStartDate);
 
@@ -111,24 +111,6 @@ describe('getFlyersByOrganizationSlug(s) tests', () => {
 
     expect(FactoryUtils.mapToValue(getFlyersResponse, 'title')).toEqual(
       FactoryUtils.mapToValue(flyers, 'title'),
-    );
-  });
-
-  test('getFlyersByOrganizationSlugs - many organizations, 3 flyers', async () => {
-    const org1 = await OrganizationFactory.getRandomOrganization();
-    const org2 = await OrganizationFactory.getRandomOrganization();
-    const flyers = (
-      await FlyerFactory.createSpecific(3, {
-        organizationSlugs: [org1.slug, org2.slug],
-      })
-    ).sort(FactoryUtils.compareByEndDate);
-    await FlyerModel.insertMany(flyers);
-
-    const getFlyersResponse1 = await FlyerRepo.getFlyersByOrganizationSlugs([org1.slug]);
-    const getFlyersResponse2 = await FlyerRepo.getFlyersByOrganizationSlugs([org2.slug]);
-
-    expect(FactoryUtils.mapToValue(getFlyersResponse1, 'title')).toEqual(
-      FactoryUtils.mapToValue(getFlyersResponse2, 'title'),
     );
   });
 });

--- a/src/tests/organization.test.ts
+++ b/src/tests/organization.test.ts
@@ -42,8 +42,8 @@ describe('getMostRecentFlyer tests:', () => {
       (await OrganizationFactory.getRandomOrganization()).slug,
     );
     const flyers = await FlyerFactory.createSpecific(_.random(2, 10), {
-      organizationSlugs: [org.slug],
-      organizations: [org],
+      organizationSlug: org.slug,
+      organizations: org,
     });
     await FlyerModel.insertMany(flyers);
 
@@ -71,17 +71,14 @@ describe('getNumFlyer tests:', () => {
     expect(numResp).toEqual(0);
   });
 
-  test('getNumFlyer - Random number of flyers', async () => {
+  test('getNumFlyer - 1 flyer', async () => {
     const org1 = await OrganizationRepo.getOrganizationBySlug(
-      (await OrganizationFactory.getRandomOrganization()).slug,
-    );
-    const org2 = await OrganizationRepo.getOrganizationBySlug(
       (await OrganizationFactory.getRandomOrganization()).slug,
     );
     const numFlyers = _.random(1, 10);
     const flyers = await FlyerFactory.createSpecific(numFlyers, {
-      organizationSlugs: [org1.slug],
-      organizations: [org1, org2],
+      organizationSlug: org1.slug,
+      organization: org1,
     });
     await FlyerModel.insertMany(flyers);
 
@@ -121,8 +118,8 @@ describe('getClicks tests:', () => {
     const numFlyers = _.random(1, 20);
     const numClicks = numFlyers * 2;
     const flyers = await FlyerFactory.createSpecific(numFlyers, {
-      organizationSlugs: [org.slug],
-      organizations: [org],
+      organizationSlug: org.slug,
+      organizations: org,
       timesClicked: 2,
     });
     await FlyerModel.insertMany(flyers);


### PR DESCRIPTION
## Overview
This PR implements flyers notification functionality as well as new changes to the Flyer and Organization models.

## Changes Made

### Flyer Model

- Added `categorySlug` field
- Made changes to how optional fields are defined to follow the same format as other models such as `Publication`
- Replaced `organizations` and `organizationSlugs` field with `organization` and `organizationSlug`
- Removed `mostRecentFlyer` and `numFlyers` FieldResolvers as requested by Jennifer
- Removed `nsfw` field in the Flyer model

### Organization Model

- Made changes to how optional fields are defined to follow the same format as other models such as `Publication`
- Made `websiteURL` required as requested by Jennifer

### Flyer Queries

- Rewrote `getFlyersByOrganizationSlug` and `getFlyersByOrganizationSlugs` queries in response to changing the Flyer model to only store a single organization

### Flyer Notifications

- Created a POST endpoint for sending a push notification for flyers
- Created `notifyNewFlyers` and `sendNewFlyerNotification` that sends a push notification to followers via FCM when the organization uploads a new flyer

### Other Changes

- Removed `pull_request` from the prod YAML file causing a new Docker image to be built upon creation of a pull request to `release`
- Rewrote test cases in response to new changes in the schema
- Removed `sendNewFlyerNotification`, `sendNewArticleNotification`, `sendNewMagazineNotification`, and `sendWeeklyDebriefNotification`. Moved these calls to be inline with their corresponding notification function.

## Test Coverage
First, I tested to see if the `followOrganization` mutation worked properly. I have a local MongoDB that contains only one user which is my personal iOS device. I went to the GraphQL playground on my local server and tested the mutation with that single user ID. The database seems to properly update so I tested the POST request and received the push notification. See screenshot below. Note that because there is a new schema, I had to rewrite the iOS code to accommodate these changes.

I then had to rewrite a couple of queries and testing factory in response to the new schema. After failing a couple of times, all test cases finally pass .See screenshot below.

One thing to note that it’s very convenient for me to test the new backend changes since I can directly test it with the frontend.

Update: Making the notification calls inline has been tested and everything works properly.

## Next Steps
- Work on implementing the new mutations for creating, editing, and deleting flyers.
- I am also wrapping up on rewriting the environment variables and creating a Volume backend onboarding document for future Volume backend newbies to reference.

## Screenshots
<img width="816" alt="Screenshot 2023-08-30 at 11 24 46 PM" src="https://github.com/cuappdev/volume-backend/assets/75594943/d9382d5f-56df-44ba-937f-198e61523d81">
<img width="583" alt="Screenshot 2023-08-30 at 11 01 35 PM" src="https://github.com/cuappdev/volume-backend/assets/75594943/236c2948-c743-4e3d-a630-3e38cfa0db86">