### PR TITLE
`createFlyer` mutation

### DIFF
--- a/src/middlewares/FlyerMiddleware.ts
+++ b/src/middlewares/FlyerMiddleware.ts
@@ -1,0 +1,15 @@
+import { MiddlewareFn } from 'type-graphql';
+import { Context } from 'vm';
+import uploadImage from '../utils';
+
+const FlyerErrorInterceptor: MiddlewareFn<Context> = async ({ args, context }, next) => {
+  try {
+    // Upload image to our upload service
+    context.imageURL = await uploadImage(args.imageB64);
+    return await next();
+  } catch (err) {
+    throw new Error('An error occured while uploading the flyer image.');
+  }
+};
+
+export default FlyerErrorInterceptor;

--- a/src/repos/FlyerRepo.ts
+++ b/src/repos/FlyerRepo.ts
@@ -233,7 +233,50 @@ const incrementTimesClicked = async (id: string): Promise<Flyer> => {
   return flyer;
 };
 
+/**
+ * Create a new flyer.
+ *
+ * @param {string} categorySlug the slug for this flyer's category
+ * @param {string} endDate the end date for this flyer's event in UTC ISO8601 format
+ * @param {string} flyerURL the URL for this flyer when tapped
+ * @param {string} imageURL the URL representing this flyer's image
+ * @param {string} location the location for this flyer's event
+ * @param {string} organizationID the ID of the organization creating this flyer
+ * @param {string} startDate the start date for this flyer's event in UTC ISO8601 format
+ * @param {string} title the title for this flyer
+ * @returns the newly created Flyer
+ */
+const createFlyer = async (
+  categorySlug: string,
+  endDate: string,
+  flyerURL: string,
+  imageURL: string,
+  location: string,
+  organizationID: string,
+  startDate: string,
+  title: string,
+): Promise<Flyer> => {
+  // Fetch organization given organization ID
+  // This call will fail if the organization cannot be found
+  const organization = await OrganizationModel.findById(new ObjectId(organizationID));
+  const organizationSlug = organization.slug;
+
+  const newFlyer = Object.assign(new Flyer(), {
+    categorySlug,
+    endDate,
+    flyerURL,
+    imageURL,
+    location,
+    organization,
+    organizationSlug,
+    startDate,
+    title,
+  });
+  return FlyerModel.create(newFlyer);
+};
+
 export default {
+  createFlyer,
   getAllFlyers,
   getFlyerByID,
   getFlyersAfterDate,

--- a/src/resolvers/FlyerResolver.ts
+++ b/src/resolvers/FlyerResolver.ts
@@ -1,7 +1,18 @@
-import { Resolver, Mutation, Arg, Query, FieldResolver, Root } from 'type-graphql';
+import {
+  Resolver,
+  Mutation,
+  Arg,
+  Query,
+  FieldResolver,
+  Root,
+  UseMiddleware,
+  Ctx,
+} from 'type-graphql';
+import { Context } from 'vm';
 import { Flyer } from '../entities/Flyer';
 import FlyerRepo from '../repos/FlyerRepo';
 import { DEFAULT_LIMIT, DEFAULT_OFFSET } from '../common/constants';
+import FlyerErrorInterceptor from '../middlewares/FlyerMiddleware';
 
 @Resolver((_of) => Flyer)
 class FlyerResolver {
@@ -154,6 +165,35 @@ class FlyerResolver {
   })
   async incrementTimesClicked(@Arg('id') id: string) {
     return FlyerRepo.incrementTimesClicked(id);
+  }
+
+  @Mutation((_returns) => Flyer, {
+    description: `Creates a single <Flyer> via given <categorySlug>, <endDate>, <flyerURL>, <imageB64>, <location>, <organizationID>, <startDate>, and <title>.
+    <startDate> and <endDate> must be in UTC ISO8601 format (e.g. YYYY-mm-ddTHH:MM:ssZ).
+    <imageB64> must be a Base64 encrypted string without 'data:image/png;base64,' prepended`,
+  })
+  @UseMiddleware(FlyerErrorInterceptor)
+  async createFlyer(
+    @Arg('categorySlug') categorySlug: string,
+    @Arg('endDate') endDate: string,
+    @Arg('flyerURL', { nullable: true }) flyerURL: string,
+    @Arg('imageB64') imageB64: string,
+    @Arg('location') location: string,
+    @Arg('organizationID') organizationID: string,
+    @Arg('startDate') startDate: string,
+    @Arg('title') title: string,
+    @Ctx() ctx: Context,
+  ) {
+    return FlyerRepo.createFlyer(
+      categorySlug,
+      endDate,
+      flyerURL,
+      ctx.imageURL,
+      location,
+      organizationID,
+      startDate,
+      title,
+    );
   }
 }
 

--- a/src/tests/flyer.test.ts
+++ b/src/tests/flyer.test.ts
@@ -202,43 +202,43 @@ describe('getTrending tests', () => {
     const getFlyersResponse = await FlyerRepo.getTrendingFlyers();
     expect(getFlyersResponse).toHaveLength(5);
   });
+});
 
-  describe('getFlyersByCategorySlug tests', () => {
-    test('getFlyersByCategorySlug - no flyers', async () => {
-      const flyers = await FlyerFactory.create(2);
-      await FlyerModel.insertMany(flyers);
+describe('getFlyersByCategorySlug tests', () => {
+  test('query flyer with invalid slug', async () => {
+    const flyers = await FlyerFactory.create(2);
+    await FlyerModel.insertMany(flyers);
 
-      const getFlyersResponse = await FlyerRepo.getFlyersByCategorySlug(Math.random().toString());
-      expect(getFlyersResponse).toHaveLength(0);
-    });
+    const getFlyersResponse = await FlyerRepo.getFlyersByCategorySlug(Math.random().toString());
+    expect(getFlyersResponse).toHaveLength(0);
+  });
 
-    test('getFlyersByCategorySlug - 1 flyer returned, multiple flyers stored', async () => {
-      const flyers = await FlyerFactory.create(4);
-      await FlyerModel.insertMany(flyers);
+  test('query flyer with existing slug', async () => {
+    const flyers = await FlyerFactory.create(4);
+    await FlyerModel.insertMany(flyers);
 
-      const randomSlug = Math.random().toString();
-      const specificFlyer = await FlyerFactory.createSpecific(1, { categorySlug: randomSlug });
-      await FlyerModel.insertMany(specificFlyer);
+    const randomSlug = Math.random().toString();
+    const specificFlyer = await FlyerFactory.createSpecific(1, { categorySlug: randomSlug });
+    await FlyerModel.insertMany(specificFlyer);
 
-      const getFlyersResponse = await FlyerRepo.getFlyersByCategorySlug(randomSlug);
-      expect(getFlyersResponse[0].categorySlug).toEqual(specificFlyer[0].categorySlug);
-      expect(getFlyersResponse).toHaveLength(1);
-    });
+    const getFlyersResponse = await FlyerRepo.getFlyersByCategorySlug(randomSlug);
+    expect(getFlyersResponse[0].categorySlug).toEqual(specificFlyer[0].categorySlug);
+    expect(getFlyersResponse).toHaveLength(1);
+  });
 
-    test('getFlyersByCategorySlug - 2 flyers returned, restrict to limit', async () => {
-      const flyers = await FlyerFactory.create(4);
-      await FlyerModel.insertMany(flyers);
+  test('query multiple flyers with existing slug', async () => {
+    const flyers = await FlyerFactory.create(4);
+    await FlyerModel.insertMany(flyers);
 
-      const randomSlug = Math.random().toString();
-      const specificFlyer = await FlyerFactory.createSpecific(4, { categorySlug: randomSlug });
-      await FlyerModel.insertMany(specificFlyer);
+    const randomSlug = Math.random().toString();
+    const specificFlyers = await FlyerFactory.createSpecific(4, { categorySlug: randomSlug });
+    await FlyerModel.insertMany(specificFlyers);
 
-      const limit = 2;
-      const getFlyersResponse = await FlyerRepo.getFlyersByCategorySlug(
-        flyers[0].categorySlug,
-        limit,
-      );
-      expect(getFlyersResponse).toHaveLength(limit);
-    });
+    const limit = 2;
+    const getFlyersResponse = await FlyerRepo.getFlyersByCategorySlug(
+      specificFlyers[0].categorySlug,
+      limit,
+    );
+    expect(getFlyersResponse).toHaveLength(limit);
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,24 @@
+import fetch from 'node-fetch-commonjs';
+
+/**
+ * Upload an image to our servers
+ *
+ * @param imageB64 the base64 string to upload
+ * @returns the URl representing the image
+ */
+const uploadImage = async (imageB64: string): Promise<string> => {
+  // Upload image via a POST request
+  const imagePayload = {
+    bucket: process.env.UPLOAD_BUCKET,
+    image: `data:image/png;base64,${imageB64}`,
+  };
+  const response = await fetch(`${process.env.UPLOAD_SERVICE_URL}/upload/`, {
+    method: 'POST',
+    body: JSON.stringify(imagePayload),
+  });
+
+  const responseData = JSON.parse(await response.text());
+  return responseData.data;
+};
+
+export default uploadImage;


### PR DESCRIPTION
## Overview

This PR implements a mutation to create a flyer.

## Changes Made

### createFlyer Mutation

- Created a mutation that returns a newly created Flyer if successful given the following arguments:
    - {string} `categorySlug` the slug for this flyer's category
    - {string} `endDate` the end date for this flyer's event in UTC ISO8601 format
    - {string} `flyerURL` the URL for this flyer when tapped
    - {string} `imageB64` the base64 string representing the flyer's image
    - {string} `location` the location for this flyer's event
    - {string} `organizationID` the ID of the organization creating this flyer
    - {string} `startDate` the start date for this flyer's event in UTC ISO8601 format
    - {string} `title` the title for this flyer
- The `imageB64` is uploaded to our Digital Ocean via a POST request.

### FlyerErrorInterceptor

- Wrote a middleware that attempts to upload an image to our servers. It will return via context the image URL if successful; otherwise, an error is thrown.
- The purpose of this middleware is to prevent a new Flyer from being created if the upload request fails.

### uploadImage

- Wrote a function that uploads an image given a base64 string and returns the generated image URL.


## Test Coverage
- I started by testing this mutation through the GraphQL playground with my local MongoDB:

```
mutation CreateFlyer($title: String!, $startDate: String!, $organizationID: String!, $location: String!, $imageB64: String!, $flyerURL: String, $endDate: String!, $categorySlug: String!) {
  createFlyer(title: $title, startDate: $startDate, organizationID: $organizationID, location: $location, imageB64: $imageB64, flyerURL: $flyerURL, endDate: $endDate, categorySlug: $categorySlug) {
    ...flyerFields
  }
}
```

- To ensure that this mutation works as expected, I provided the following invalid arguments to see if the request fails:
    - Invalid `organizationID`
    - Invalid `startDate` and `endDate` format (note that the frontend must provide this in the correct format and timezone; the backend will not do any timezone conversion)
        - Example valid format: `YYYY-mm-ddTHH:MM:ssZ`
        - This is required in order to store the dates as Date objects in MongoDB.
    - Empty `flyerURL` since this is optional
    - Invalid `imageB64`
        - An error is thrown by GraphQL if the upload request fails. See second screenshot below.
- See the first screenshot below for a successful request.


## Next Steps
- Work on implementing the editing and deleting flyers mutations.
- I believe that all functions should have proper documentation and the test suite description should also be refactored. Perhaps this could be something to do in the future.


## Screenshots
<img width="1440" alt="create_flyer_1" src="https://github.com/cuappdev/volume-backend/assets/75594943/f02b20ab-e5bd-4bd2-bed9-14e29ea835fd">
<img width="1440" alt="create_flyer_2" src="https://github.com/cuappdev/volume-backend/assets/75594943/6670ffe5-ab22-457e-aa97-551099436c90">