### PR TITLE
Changing specifications for getFlyersBeforeDate and getFlyersAfterDate

### DIFF
--- a/src/resolvers/FlyerResolver.ts
+++ b/src/resolvers/FlyerResolver.ts
@@ -98,8 +98,8 @@ class FlyerResolver {
 
   @Query((_returns) => [Flyer], {
     nullable: false,
-    description: `Returns a list of <Flyers> <since> a given date, limited by <limit>. 
-  <since> is formatted as an compliant RFC 2822 timestamp. Valid examples include: "2019-01-31", "Aug 9, 1995", "Wed, 09 Aug 1995 00:00:00", etc. Default <limit> is ${DEFAULT_LIMIT}`,
+    description: `Returns a list of <Flyers> <since> a given date, limited by <limit>.
+    <since> must be in UTC ISO8601 format (e.g. YYYY-mm-ddTHH:MM:ssZ). Default <limit> is ${DEFAULT_LIMIT}`,
   })
   async getFlyersAfterDate(
     @Arg('since') since: string,
@@ -110,8 +110,8 @@ class FlyerResolver {
 
   @Query((_returns) => [Flyer], {
     nullable: false,
-    description: `Returns a list of <Flyers> <before> a given date, limited by <limit>. 
-  <before> is formatted as an compliant RFC 2822 timestamp. Valid examples include: "2019-01-31", "Aug 9, 1995", "Wed, 09 Aug 1995 00:00:00", etc. Default <limit> is ${DEFAULT_LIMIT}`,
+    description: `Returns a list of <Flyers> <before> a given date, limited by <limit>.
+    <before> must be in UTC ISO8601 format (e.g. YYYY-mm-ddTHH:MM:ssZ). Default <limit> is ${DEFAULT_LIMIT}`,
   })
   async getFlyersBeforeDate(
     @Arg('before') before: string,


### PR DESCRIPTION
## Overview
This PR requires that the since parameter in getFlyersAfterDate and the before parameter in getFlyersBeforeDate both be in UTC ISO8601 format (e.g. YYYY-mm-ddTHH:MM:ssZ).

## Changes Made

- Changed specification for getFlyersAfterDate
- Changed specification for getFlyersBeforeDate

## Test Coverage
I tested the changes in the GraphQL Playground and passed in since and before parameters in UTC ISO8601 format.

## Screenshots (delete if not applicable)
<img width="1470" alt="image" src="https://github.com/cuappdev/volume-backend/assets/68517064/8d362744-95c2-4252-acf0-d2926511302c">
<img width="1470" alt="image" src="https://github.com/cuappdev/volume-backend/assets/68517064/50ce36cf-1fd4-448f-b1c5-74e7b02cddb6">