### PR TITLE
Fixed issue with edit flyer

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -168,7 +168,7 @@ const main = async () => {
     }
 
     const oldFlyer = await FlyerModel.findById(flyerID);
-    if (oldFlyer == null) {
+    if (!oldFlyer) {
       return res.status(400).json({ error: 'flyerID not associated with any flyers' });
     }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,6 +6,7 @@ import { buildSchema } from 'type-graphql';
 
 import { ApolloServer } from 'apollo-server-express';
 import multer, { diskStorage } from 'multer';
+import path from 'path';
 import { dbConnection } from './db/DBConnection';
 import { Flyer, FlyerModel } from './entities/Flyer';
 import ArticleRepo from './repos/ArticleRepo';
@@ -20,7 +21,7 @@ import OrganizationResolver from './resolvers/OrganizationResolver';
 import PublicationResolver from './resolvers/PublicationResolver';
 import UserResolver from './resolvers/UserResolver';
 import utils from './utils';
-import path from 'path';
+import FlyerRepo from './repos/FlyerRepo';
 
 const main = async () => {
   const schema = await buildSchema({
@@ -95,7 +96,7 @@ const main = async () => {
       startDate
       title
    * There also must be a file with the key `image` which should be the image
-      associated with the flyer.
+      associated with the flyer. The image type must be png.
    */
   app.post('/flyers/', upload.single('image'), async (req, res) => {
     // Ensure there is an image file present
@@ -151,53 +152,39 @@ const main = async () => {
 
   /**
    * Route to edit a flyer, uses form-data.
-   * Requires flyerID field for which flyer we are editing.
-   * Other flyer fields can optionally be sent in the form-data as key-value pairs
-   * Image URL should use a file in the form-data.
+   *
+   * Requires `flyerID` field for which flyer we are editing.
+   * Other flyer fields can optionally be sent in the form-data as key-value pairs.
+   *
+   * The file with the key `image` which should be the image associated with the flyer.
+   * The image type must be png.
    */
-  app.post('/flyers/edit/', upload.single('file'), async (req, res) => {
-    const {
-      categorySlug,
-      endDate,
-      flyerURL,
-      location,
-      organizationID,
-      startDate,
-      title,
-      flyerID,
-    } = req.body;
+  app.post('/flyers/edit/', upload.single('image'), async (req, res) => {
+    const { categorySlug, endDate, flyerURL, location, startDate, title, flyerID } = req.body;
 
     // Assert request body has required fields
-    if (flyerID == null) {
+    if (!flyerID) {
       return res.status(400).json({ error: 'Missing a required flyerID field' });
     }
+
     const oldFlyer = await FlyerModel.findById(flyerID);
     if (oldFlyer == null) {
       return res.status(400).json({ error: 'flyerID not associated with any flyers' });
     }
+
     // Get the file from form-data and await the upload service
     const imageURL = req.file ? await utils.uploadImage(req.file) : undefined;
-
-    // Find the organization related to the request
-    const organization = await OrganizationRepo.getOrganizationByID(organizationID);
-    const organizationSlug = organization.slug;
-
-    FlyerModel.updateOne(
-      { id: flyerID },
-      {
-        $set: {
-          categorySlug: categorySlug ?? oldFlyer.categorySlug,
-          endDate: endDate ?? oldFlyer.endDate,
-          flyerURL: flyerURL ?? oldFlyer.flyerURL,
-          imageURL: imageURL ?? oldFlyer.imageURL,
-          location: location ?? oldFlyer.location,
-          organization: organization ?? oldFlyer.organization,
-          organizationSlug: organizationSlug ?? oldFlyer.organizationSlug,
-          startDate: startDate ?? oldFlyer.startDate,
-          title: title ?? oldFlyer.title,
-        },
-      },
+    await FlyerRepo.editFlyer(
+      flyerID,
+      categorySlug,
+      endDate,
+      flyerURL,
+      imageURL,
+      location,
+      startDate,
+      title,
     );
+
     return res.status(201).json(await FlyerModel.findById(flyerID));
   });
 


### PR DESCRIPTION
## Overview

Fixed issues with editing flyer via the form data HTTP request.

## Changes Made

There was an issue where the server would crash if the user did not provide the field `organizationID`. There were also issues where editing the flyer did not even work at all.

I fixed these issues by using the `EditFlyer` function in the `FlyerRepo` which properly handles the logic for editing a flyer.

## Test Coverage

I used Postman to test as well as my local iOS device. I tested every single field with different combinations and it seemed to work just fine. The uploaded images seem to work as well and it even deletes the old image from our storage. I don’t have any screenshots, but I’m confident that this works as expected.